### PR TITLE
Allowing to set the TextField's type value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.log
 .DS_Store
 node_modules
-coverage
 .cache
 .rts2_cache_cjs
 .rts2_cache_esm

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 .DS_Store
 node_modules
+coverage
 .cache
 .rts2_cache_cjs
 .rts2_cache_esm

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -4,7 +4,15 @@ import { Field, FieldRenderProps } from 'react-final-form';
 import { TextField as MuiTextField } from '@material-ui/core';
 import { TextFieldProps as MuiTextFieldProps } from '@material-ui/core/TextField/TextField';
 
-export function TextField(props: Partial<MuiTextFieldProps>) {
+export const TYPE_PASSWORD = 'password';
+export const TYPE_TEXT = 'text';
+
+// Restricts the type values to 'password' and 'text'
+export type MuiRffTextFieldProps = Omit<MuiTextFieldProps, 'type'> & {
+	type: typeof TYPE_PASSWORD | typeof TYPE_TEXT;
+};
+
+export function TextField(props: Partial<MuiRffTextFieldProps>) {
 	const { name } = props;
 
 	return (
@@ -15,9 +23,9 @@ export function TextField(props: Partial<MuiTextFieldProps>) {
 	);
 }
 
-function TextFieldWrapper(props: FieldRenderProps<MuiTextFieldProps, HTMLInputElement>) {
+function TextFieldWrapper(props: FieldRenderProps<MuiRffTextFieldProps, HTMLInputElement>) {
 	const {
-		input: { name, onChange, value, ...restInput },
+		input: { name, onChange, value, type = TYPE_TEXT, ...restInput },
 		meta,
 		...rest
 	} = props;
@@ -34,6 +42,7 @@ function TextFieldWrapper(props: FieldRenderProps<MuiTextFieldProps, HTMLInputEl
 			name={name}
 			value={value}
 			margin="normal"
+			type={type}
 			InputLabelProps={{ shrink: !!value }}
 			{...lessrest}
 			inputProps={restInput as any}

--- a/test/TextField.test.tsx
+++ b/test/TextField.test.tsx
@@ -151,5 +151,6 @@ describe('TextField', () => {
 
 		expect(input.value).toBeDefined();
 		expect(input.type).toBe(TYPE_PASSWORD);
+		expect(rendered).toMatchSnapshot();
 	});
 });

--- a/test/TextField.test.tsx
+++ b/test/TextField.test.tsx
@@ -7,12 +7,14 @@ import * as Yup from 'yup';
 
 import { makeValidate, TextField } from '../src';
 import { render, fireEvent, act } from './TestUtils';
+import { TYPE_TEXT, TYPE_PASSWORD } from '../src/TextField';
 
 interface ComponentProps {
 	initialValues: FormData;
 	validator?: any;
 	setInputLabelProps?: boolean;
 	setHelperText?: boolean;
+	type?: typeof TYPE_TEXT | typeof TYPE_PASSWORD;
 }
 
 interface FormData {
@@ -31,7 +33,13 @@ describe('TextField', () => {
 		shrink: false,
 	};
 
-	function TextFieldComponent({ initialValues, validator, setInputLabelProps, setHelperText }: ComponentProps) {
+	function TextFieldComponent({
+		initialValues,
+		validator,
+		setInputLabelProps,
+		setHelperText,
+		type = TYPE_TEXT,
+	}: ComponentProps) {
 		const onSubmit = (values: FormData) => {
 			console.log(values);
 		};
@@ -55,6 +63,7 @@ describe('TextField', () => {
 							required={true}
 							helperText={setHelperText ? helperText : undefined}
 							InputLabelProps={setInputLabelProps ? inputLabelProps : undefined}
+							type={type}
 						/>
 					</form>
 				)}
@@ -134,5 +143,13 @@ describe('TextField', () => {
 		expect(error.tagName).toBe('P');
 
 		expect(rendered).toMatchSnapshot();
+	});
+
+	it('allows to set its type to password', async () => {
+		const rendered = render(<TextFieldComponent initialValues={initialValues} type={TYPE_PASSWORD} />);
+		const input = (await rendered.getByRole('textbox')) as HTMLInputElement;
+
+		expect(input.value).toBeDefined();
+		expect(input.type).toBe(TYPE_PASSWORD);
 	});
 });

--- a/test/__snapshots__/TextField.test.tsx.snap
+++ b/test/__snapshots__/TextField.test.tsx.snap
@@ -31,6 +31,7 @@ Object {
               class="MuiInputBase-input-50 MuiInput-input-35"
               name="hello"
               required=""
+              type="text"
               value="something here"
             />
           </div>
@@ -65,6 +66,7 @@ Object {
             class="MuiInputBase-input-50 MuiInput-input-35"
             name="hello"
             required=""
+            type="text"
             value="something here"
           />
         </div>
@@ -156,6 +158,7 @@ Object {
               class="MuiInputBase-input-50 MuiInput-input-35"
               name="hello"
               required=""
+              type="text"
               value="something here"
             />
           </div>
@@ -195,6 +198,7 @@ Object {
             class="MuiInputBase-input-50 MuiInput-input-35"
             name="hello"
             required=""
+            type="text"
             value="something here"
           />
         </div>
@@ -291,6 +295,7 @@ Object {
               class="MuiInputBase-input-50 MuiInput-input-35"
               name="hello"
               required=""
+              type="text"
               value="something here"
             />
           </div>
@@ -325,6 +330,7 @@ Object {
             class="MuiInputBase-input-50 MuiInput-input-35"
             name="hello"
             required=""
+            type="text"
             value="something here"
           />
         </div>
@@ -416,6 +422,7 @@ Object {
               class="MuiInputBase-input-50 MuiInput-input-35"
               name="hello"
               required=""
+              type="text"
               value=""
             />
           </div>
@@ -455,6 +462,7 @@ Object {
             class="MuiInputBase-input-50 MuiInput-input-35"
             name="hello"
             required=""
+            type="text"
             value=""
           />
         </div>

--- a/test/__snapshots__/TextField.test.tsx.snap
+++ b/test/__snapshots__/TextField.test.tsx.snap
@@ -1,5 +1,132 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextField allows to set its type to password 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <form
+        novalidate=""
+      >
+        <div
+          class="MuiFormControl-root-2 MuiTextField-root-1 MuiFormControl-marginNormal-3 MuiFormControl-fullWidth-5"
+        >
+          <label
+            class="MuiFormLabel-root-18 MuiInputLabel-root-6 MuiInputLabel-formControl-12 MuiInputLabel-animated-15 MuiInputLabel-shrink-14 MuiFormLabel-filled-23 MuiFormLabel-required-24 MuiInputLabel-required-10"
+            data-shrink="true"
+          >
+            Test
+            <span
+              class="MuiFormLabel-asterisk-25 MuiInputLabel-asterisk-11"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="MuiInputBase-root-39 MuiInput-root-26 MuiInput-underline-31 MuiInputBase-fullWidth-49 MuiInput-fullWidth-34 MuiInputBase-formControl-40 MuiInput-formControl-27"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input-50 MuiInput-input-35"
+              name="hello"
+              required=""
+              type="password"
+              value="something here"
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      novalidate=""
+    >
+      <div
+        class="MuiFormControl-root-2 MuiTextField-root-1 MuiFormControl-marginNormal-3 MuiFormControl-fullWidth-5"
+      >
+        <label
+          class="MuiFormLabel-root-18 MuiInputLabel-root-6 MuiInputLabel-formControl-12 MuiInputLabel-animated-15 MuiInputLabel-shrink-14 MuiFormLabel-filled-23 MuiFormLabel-required-24 MuiInputLabel-required-10"
+          data-shrink="true"
+        >
+          Test
+          <span
+            class="MuiFormLabel-asterisk-25 MuiInputLabel-asterisk-11"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root-39 MuiInput-root-26 MuiInput-underline-31 MuiInputBase-fullWidth-49 MuiInput-fullWidth-34 MuiInputBase-formControl-40 MuiInput-formControl-27"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input-50 MuiInput-input-35"
+            name="hello"
+            required=""
+            type="password"
+            value="something here"
+          />
+        </div>
+      </div>
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`TextField can override InputLabelProps 1`] = `
 Object {
   "asFragment": [Function],


### PR DESCRIPTION
**The problem**
The current implementation does not take account the 'type' property when creating the MuiTextField component. With this PR we will be able to set that prop to 'text' (default) or 'password'.
**The solution**
A type (MuiRffTextFieldProps) was created to guarantee that the property type's value is restricted to those above and that value is configured when creating the MuiTextField instance
The test 'allows to set its type to password' was added to validate the implementation. However, all snapshots had be updated.