### PR TITLE
Minor change to allow Checkboxes to have a ReactNode as its label

### DIFF
--- a/src/Checkboxes.tsx
+++ b/src/Checkboxes.tsx
@@ -12,12 +12,12 @@ import { FormControlLabelProps } from '@material-ui/core/FormControlLabel';
 import { FormGroupProps } from '@material-ui/core/FormGroup';
 import { FormHelperTextProps } from '@material-ui/core/FormHelperText';
 import { FormLabelProps } from '@material-ui/core/FormLabel';
-import React, { useState } from 'react';
+import React, { useState, ReactNode } from 'react';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
 export interface CheckboxData {
-	label: string;
+	label: ReactNode;
 	value: any;
 }
 

--- a/test/Checkboxes.test.tsx
+++ b/test/Checkboxes.test.tsx
@@ -7,8 +7,8 @@ import { CheckboxData, Checkboxes, makeValidate } from '../src';
 import { render, fireEvent, act } from './TestUtils';
 
 interface ComponentProps {
-	data: CheckboxData[];
-	initialValues: FormData;
+	data: CheckboxData | CheckboxData[];
+	initialValues?: FormData;
 	validator?: any;
 }
 
@@ -134,5 +134,22 @@ describe('Checkboxes', () => {
 		expect(error.innerHTML).toContain(message);
 
 		expect(rendered).toMatchSnapshot();
+	});
+
+	it('renders without errors when the label is a HTML element', async () => {
+		await act(async () => {
+			const labelId = 'label-id';
+			const rendered = render(
+				<CheckboxComponent
+					data={{
+						label: <div data-testid={labelId}>Can it have a HTML elment as label?</div>,
+						value: 'Yes, it can',
+					}}
+				/>
+			);
+			const elem = rendered.getByTestId(labelId) as HTMLElement;
+			expect(elem.tagName.toLocaleLowerCase()).toBe('div');
+			expect(rendered).toMatchSnapshot();
+		});
 	});
 });

--- a/test/__snapshots__/Checkboxes.test.tsx.snap
+++ b/test/__snapshots__/Checkboxes.test.tsx.snap
@@ -817,6 +817,157 @@ Object {
 }
 `;
 
+exports[`Checkboxes renders without errors when the label is a HTML element 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <form
+        novalidate=""
+      >
+        <label
+          class="MuiFormControlLabel-root-1"
+        >
+          <span
+            aria-disabled="false"
+            class="MuiButtonBase-root-26 MuiIconButton-root-17 PrivateSwitchBase-root-13 MuiCheckbox-root-7 MuiCheckbox-colorSecondary-12 MuiIconButton-colorSecondary-22"
+          >
+            <span
+              class="MuiIconButton-label-25"
+            >
+              <input
+                class="PrivateSwitchBase-input-16"
+                data-indeterminate="false"
+                name="best"
+                type="checkbox"
+                value=""
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-29"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root-38 MuiFormControlLabel-label-6 MuiTypography-body1-40"
+          >
+            <div
+              data-testid="label-id"
+            >
+              Can it have a HTML elment as label?
+            </div>
+          </span>
+        </label>
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      novalidate=""
+    >
+      <label
+        class="MuiFormControlLabel-root-1"
+      >
+        <span
+          aria-disabled="false"
+          class="MuiButtonBase-root-26 MuiIconButton-root-17 PrivateSwitchBase-root-13 MuiCheckbox-root-7 MuiCheckbox-colorSecondary-12 MuiIconButton-colorSecondary-22"
+        >
+          <span
+            class="MuiIconButton-label-25"
+          >
+            <input
+              class="PrivateSwitchBase-input-16"
+              data-indeterminate="false"
+              name="best"
+              type="checkbox"
+              value=""
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-29"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          class="MuiTypography-root-38 MuiFormControlLabel-label-6 MuiTypography-body1-40"
+        >
+          <div
+            data-testid="label-id"
+          >
+            Can it have a HTML elment as label?
+          </div>
+        </span>
+      </label>
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Checkboxes requires one checkbox 1`] = `
 Object {
   "asFragment": [Function],


### PR DESCRIPTION
When working with i18l the label of any element must be able to accept a ReactNode (from string to ReactElement) as theirs values.
An example can be described when we are using react-intl. Any text in the application is rendered by a component.
```html
<Grid item xs={2}>
  <Typography align="left">
    <FormattedMessage {...messagesDescriptors.LabelName} />:
  </Typography>
</Grid>
```
Thus, the mui-rff should be able to handle this. This PR contains the related patch for Checkboxes
```html
<CheckboxComponent
  data={{
    label: <div id="creative-div-id">Can it have a HTML elment as label?</div>,
    value: 'Yes, it can',
  }}
/>
```
I don't know if there are other place to make changes like this one, and this PR can lead the way