### PR TITLE
export SelectProps

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -20,7 +20,7 @@ export interface SelectData {
 	value: string;
 }
 
-interface SelectProps {
+export interface SelectProps {
 	name: string;
 	label: string;
 	required?: boolean;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 export { Autocomplete, AutocompleteData } from './Autocomplete';
 export { Checkboxes, CheckboxData } from './Checkboxes';
 export { Radios, RadioData } from './Radios';
-export { Select, SelectData } from './Select';
+export { Select, SelectData, SelectProps } from './Select';
 export { KeyboardDatePicker } from './KeyboardDatePicker';
 export { DatePicker } from './DatePicker';
 export { TimePicker } from './TimePicker';


### PR DESCRIPTION
This is needed when you want to set some props as default by wrapping the component.

For example : 
```tsx
export const SelectField: FC<SelectProps> = props => {
  return <MuiRffSelect variant="filled" {...props}/>
}
```