### PR TITLE
fix(helperText): default "helperText" not visible

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -35,6 +35,7 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 		...rest
 	} = props;
 
+	const { helperText, ...lessrest } = rest as any;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
 	return pickerProviderWrapper(
@@ -42,14 +43,14 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 		<MuiDatePicker
 			fullWidth={true}
 			autoOk={true}
-			helperText={showError ? meta.error || meta.submitError : undefined}
+			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
 			format="yyyy-MM-dd"
 			margin="normal"
 			onChange={onChange}
 			name={name}
 			value={(value as any) === '' ? null : value}
-			{...rest}
+			{...lessrest}
 			inputProps={restInput}
 		/>
 	);

--- a/src/KeyboardDatePicker.tsx
+++ b/src/KeyboardDatePicker.tsx
@@ -38,6 +38,7 @@ function KeyboardDatePickerWrapper(props: DatePickerWrapperProps) {
 		...rest
 	} = props;
 
+	const { helperText, ...lessrest } = rest as any;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
 	return pickerProviderWrapper(
@@ -46,7 +47,7 @@ function KeyboardDatePickerWrapper(props: DatePickerWrapperProps) {
 			disableToolbar
 			fullWidth={true}
 			autoOk={true}
-			helperText={showError ? meta.error || meta.submitError : undefined}
+			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
 			variant="inline"
 			format="yyyy-MM-dd"
@@ -54,7 +55,7 @@ function KeyboardDatePickerWrapper(props: DatePickerWrapperProps) {
 			onChange={onChange}
 			name={name}
 			value={(value as any) === '' ? null : value}
-			{...rest}
+			{...lessrest}
 			inputProps={restInput}
 		/>
 	);

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -38,7 +38,7 @@ function TextFieldWrapper(props: FieldRenderProps<TextFieldProps, HTMLInputEleme
 	return (
 		<MuiTextField
 			fullWidth={true}
-			helperText={helperText !== undefined ? helperText : showError ? meta.error || meta.submitError : undefined}
+			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
 			onChange={onChange}
 			name={name}

--- a/src/TimePicker.tsx
+++ b/src/TimePicker.tsx
@@ -35,6 +35,7 @@ function TimePickerWrapper(props: TimePickerWrapperProps) {
 		...rest
 	} = props;
 
+	const { helperText, ...lessrest } = rest as any;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
 	return pickerProviderWrapper(
@@ -42,13 +43,13 @@ function TimePickerWrapper(props: TimePickerWrapperProps) {
 		<MuiTimePicker
 			fullWidth={true}
 			autoOk={true}
-			helperText={showError ? meta.error || meta.submitError : undefined}
+			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
 			margin="normal"
 			onChange={onChange}
 			name={name}
 			value={(value as any) === '' ? null : value}
-			{...rest}
+			{...lessrest}
 			inputProps={restInput}
 		/>
 	);


### PR DESCRIPTION
* TextField assign default "helperText", then it displays, but it always displays default helperText, when error occurring.
* DatePicker, KeyboardDatePicker, TimePicker assign default "helperText", but they never display, but when error occurring, error displays.