### PR TITLE
labels can use ReactNode everywhere it is supported in MUI

### DIFF
--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, ReactNode } from 'react';
 
 import { Field, FieldRenderProps, FieldProps } from 'react-final-form';
 
@@ -15,7 +15,7 @@ export type AutocompleteData = {
 
 export interface AutocompleteProps extends Partial<MuiAutocompleteProps<any>> {
 	name: string;
-	label: string;
+	label: ReactNode;
 	helperText?: string;
 	required?: boolean;
 	multiple?: boolean;
@@ -38,7 +38,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
 };
 
 interface AutocompleteWrapperProps extends FieldRenderProps<MuiTextFieldProps, HTMLElement> {
-	label: string;
+	label: ReactNode;
 	required?: boolean;
 	multiple?: boolean;
 	textFieldProps?: Partial<MuiTextFieldProps>;

--- a/src/Checkboxes.tsx
+++ b/src/Checkboxes.tsx
@@ -26,7 +26,7 @@ export interface CheckboxData {
 export interface CheckboxesProps extends Partial<MuiCheckboxProps> {
 	name: string;
 	data: CheckboxData | CheckboxData[];
-	label?: string;
+	label?: ReactNode;
 	required?: boolean;
 	helperText?: string;
 	fieldProps?: Partial<FieldProps<any, any>>;

--- a/src/Radios.tsx
+++ b/src/Radios.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 
 import {
 	Radio as MuiRadio,
@@ -18,7 +18,7 @@ import {
 import { Field, FieldProps, useFormState } from 'react-final-form';
 
 export interface RadioData {
-	label: string;
+	label: ReactNode;
 	value: string;
 	disabled?: boolean;
 }
@@ -26,7 +26,7 @@ export interface RadioData {
 export interface RadiosProps extends Partial<RadioProps> {
 	name: string;
 	data: RadioData[];
-	label?: string;
+	label?: ReactNode;
 	required?: boolean;
 	helperText?: string;
 	formLabelProps?: Partial<FormLabelProps>;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 
 import {
 	Select as MuiSelect,
@@ -23,7 +23,7 @@ export interface SelectData {
 
 export interface SelectProps extends Partial<MuiSelectProps> {
 	name: string;
-	label: string;
+	label: ReactNode;
 	required?: boolean;
 	multiple?: boolean;
 	helperText?: string;

--- a/src/Switches.tsx
+++ b/src/Switches.tsx
@@ -26,7 +26,7 @@ export interface SwitchData {
 export interface SwitchesProps extends Partial<MuiSwitchProps> {
 	name: string;
 	data: SwitchData | SwitchData[];
-	label?: string;
+	label?: ReactNode;
 	required?: boolean;
 	helperText?: string;
 	fieldProps?: Partial<FieldProps<any, any>>;


### PR DESCRIPTION
Some labels were restricted to the `string` type. This allows `ReactNode` to be used everywhere that MUI supports it.