### PR TITLE
allow rendering <Select> without a label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-rff",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "license": "MIT",
   "description": "Set of modern wrapper components to facilitate using Material UI with React Final Form",
   "repository": {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -23,7 +23,7 @@ export interface SelectData {
 
 export interface SelectProps extends Partial<MuiSelectProps> {
 	name: string;
-	label: string;
+	label?: string;
 	required?: boolean;
 	multiple?: boolean;
 	helperText?: string;
@@ -73,8 +73,10 @@ export function Select(props: SelectProps) {
 	const inputLabel = React.useRef<HTMLLabelElement>(null);
 	const [labelWidthState, setLabelWidthState] = React.useState(0);
 	React.useEffect(() => {
-		setLabelWidthState(inputLabel.current!.offsetWidth);
-	}, []);
+		if (label) {
+			setLabelWidthState(inputLabel.current!.offsetWidth);
+		}
+	}, [label]);
 
 	return (
 		<FormControl required={required} error={!!errorState} margin="normal" fullWidth={true} {...formControlProps}>
@@ -90,7 +92,7 @@ export function Select(props: SelectProps) {
 						value={value}
 						onChange={onChange}
 						multiple={multiple}
-						labelWidth={variant === 'outlined' ? labelWidthState : labelWidth}
+						labelWidth={variant === 'outlined' && !!label ? labelWidthState : labelWidth}
 						inputProps={{ required: required, ...restInput }}
 						{...restSelectProps}
 					>

--- a/test/Select.test.tsx
+++ b/test/Select.test.tsx
@@ -12,7 +12,7 @@ describe('Select', () => {
 			data: SelectData[];
 			initialValues: FormData;
 			validator?: any;
-			noLabel?: boolean;
+			label: boolean;
 			variant?: SelectProps['variant'];
 		}
 
@@ -30,7 +30,7 @@ describe('Select', () => {
 			best: 'bar',
 		};
 
-		function SelectComponent({ initialValues, data, validator, noLabel, variant }: ComponentProps) {
+		function SelectComponent({ initialValues, data, validator, label, variant }: ComponentProps) {
 			const onSubmit = (values: FormData) => {
 				console.log(values);
 			};
@@ -49,7 +49,7 @@ describe('Select', () => {
 					render={({ handleSubmit }) => (
 						<form onSubmit={handleSubmit} noValidate data-testid="form">
 							<Select
-								label={noLabel ? undefined : 'Test'}
+								label={(label && 'Test') || undefined}
 								required={true}
 								name="best"
 								data={data}
@@ -63,13 +63,17 @@ describe('Select', () => {
 
 		it('renders without errors', async () => {
 			await act(async () => {
-				const rendered = render(<SelectComponent data={selectData} initialValues={initialValues} />);
+				const rendered = render(
+					<SelectComponent data={selectData} initialValues={initialValues} label={true} />
+				);
 				expect(rendered).toMatchSnapshot();
 			});
 		});
 
 		it('renders a selected item', async () => {
-			const { findByTestId } = render(<SelectComponent data={selectData} initialValues={initialValues} />);
+			const { findByTestId } = render(
+				<SelectComponent data={selectData} initialValues={initialValues} label={true} />
+			);
 
 			const form = await findByTestId('form');
 			const input = form.getElementsByTagName('input').item(0) as HTMLInputElement;
@@ -78,7 +82,9 @@ describe('Select', () => {
 
 		it('has the Test label', async () => {
 			await act(async () => {
-				const rendered = render(<SelectComponent data={selectData} initialValues={initialValues} />);
+				const rendered = render(
+					<SelectComponent data={selectData} initialValues={initialValues} label={true} />
+				);
 				const elem = rendered.getByText('Test') as HTMLLegendElement;
 				expect(elem.tagName).toBe('LABEL');
 			});
@@ -86,7 +92,9 @@ describe('Select', () => {
 
 		it('has the required *', async () => {
 			await act(async () => {
-				const rendered = render(<SelectComponent data={selectData} initialValues={initialValues} />);
+				const rendered = render(
+					<SelectComponent data={selectData} initialValues={initialValues} label={true} />
+				);
 				const elem = rendered.getByText('*') as HTMLSpanElement;
 				expect(elem.tagName).toBe('SPAN');
 				expect(elem.innerHTML).toBe(' *');
@@ -96,7 +104,7 @@ describe('Select', () => {
 		it('renders outlined', async () => {
 			await act(async () => {
 				const rendered = render(
-					<SelectComponent data={selectData} initialValues={initialValues} variant="outlined" />
+					<SelectComponent data={selectData} initialValues={initialValues} variant="outlined" label={true} />
 				);
 				expect(rendered).toMatchSnapshot();
 			});
@@ -105,7 +113,7 @@ describe('Select', () => {
 		it('renders outlined without a label', async () => {
 			await act(async () => {
 				const rendered = render(
-					<SelectComponent data={selectData} initialValues={initialValues} variant="outlined" noLabel />
+					<SelectComponent data={selectData} initialValues={initialValues} variant="outlined" label={false} />
 				);
 				expect(rendered).toMatchSnapshot();
 			});

--- a/test/Select.test.tsx
+++ b/test/Select.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Button, MenuItem } from '@material-ui/core';
 import { Form } from 'react-final-form';
 
-import { Select, SelectData } from '../src';
+import { Select, SelectData, SelectProps } from '../src';
 import { act, render, fireEvent } from './TestUtils';
 
 describe('Select', () => {
@@ -12,6 +12,8 @@ describe('Select', () => {
 			data: SelectData[];
 			initialValues: FormData;
 			validator?: any;
+			noLabel?: boolean;
+			variant?: SelectProps['variant'];
 		}
 
 		interface FormData {
@@ -28,7 +30,7 @@ describe('Select', () => {
 			best: 'bar',
 		};
 
-		function SelectComponent({ initialValues, data, validator }: ComponentProps) {
+		function SelectComponent({ initialValues, data, validator, noLabel, variant }: ComponentProps) {
 			const onSubmit = (values: FormData) => {
 				console.log(values);
 			};
@@ -46,7 +48,13 @@ describe('Select', () => {
 					validate={validate}
 					render={({ handleSubmit }) => (
 						<form onSubmit={handleSubmit} noValidate data-testid="form">
-							<Select label="Test" required={true} name="best" data={data} />
+							<Select
+								label={noLabel ? undefined : 'Test'}
+								required={true}
+								name="best"
+								data={data}
+								variant={variant}
+							/>
 						</form>
 					)}
 				/>
@@ -82,6 +90,24 @@ describe('Select', () => {
 				const elem = rendered.getByText('*') as HTMLSpanElement;
 				expect(elem.tagName).toBe('SPAN');
 				expect(elem.innerHTML).toBe(' *');
+			});
+		});
+
+		it('renders outlined', async () => {
+			await act(async () => {
+				const rendered = render(
+					<SelectComponent data={selectData} initialValues={initialValues} variant="outlined" />
+				);
+				expect(rendered).toMatchSnapshot();
+			});
+		});
+
+		it('renders outlined without a label', async () => {
+			await act(async () => {
+				const rendered = render(
+					<SelectComponent data={selectData} initialValues={initialValues} variant="outlined" noLabel />
+				);
+				expect(rendered).toMatchSnapshot();
 			});
 		});
 

--- a/test/Select.test.tsx
+++ b/test/Select.test.tsx
@@ -48,13 +48,7 @@ describe('Select', () => {
 					validate={validate}
 					render={({ handleSubmit }) => (
 						<form onSubmit={handleSubmit} noValidate data-testid="form">
-							<Select
-								label={(label && 'Test') || undefined}
-								required={true}
-								name="best"
-								data={data}
-								variant={variant}
-							/>
+							<Select label={label && 'Test'} required={true} name="best" data={data} variant={variant} />
 						</form>
 					)}
 				/>

--- a/test/__snapshots__/Select.test.tsx.snap
+++ b/test/__snapshots__/Select.test.tsx.snap
@@ -222,6 +222,370 @@ Object {
 }
 `;
 
+exports[`Select basic component renders outlined 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <form
+        data-testid="form"
+        novalidate=""
+      >
+        <div
+          class="MuiFormControl-root-1 MuiFormControl-marginNormal-2 MuiFormControl-fullWidth-4"
+        >
+          <label
+            class="MuiFormLabel-root-17 MuiInputLabel-root-5 MuiInputLabel-formControl-11 MuiInputLabel-animated-14 MuiFormLabel-required-23 MuiInputLabel-required-9"
+            data-shrink="false"
+            for="best"
+          >
+            Test
+            <span
+              class="MuiFormLabel-asterisk-24 MuiInputLabel-asterisk-10"
+            >
+               
+              *
+            </span>
+          </label>
+          <div
+            class="MuiInputBase-root-50 MuiOutlinedInput-root-35 MuiInputBase-formControl-51"
+          >
+            <div
+              aria-haspopup="listbox"
+              aria-labelledby=" mui-component-select-best"
+              class="MuiSelect-root-25 MuiSelect-select-26 MuiSelect-selectMenu-29 MuiSelect-outlined-28 MuiInputBase-input-61 MuiOutlinedInput-input-45"
+              id="mui-component-select-best"
+              role="button"
+              tabindex="0"
+            >
+              Bar
+            </div>
+            <input
+              name="best"
+              type="hidden"
+              value="bar"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-68 MuiSelect-icon-31 MuiSelect-iconOutlined-34"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root-81 MuiOutlinedInput-notchedOutline-44"
+              style="padding-left: 8px;"
+            >
+              <legend
+                class="PrivateNotchedOutline-legend-82"
+                style="width: 0.01px;"
+              >
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      data-testid="form"
+      novalidate=""
+    >
+      <div
+        class="MuiFormControl-root-1 MuiFormControl-marginNormal-2 MuiFormControl-fullWidth-4"
+      >
+        <label
+          class="MuiFormLabel-root-17 MuiInputLabel-root-5 MuiInputLabel-formControl-11 MuiInputLabel-animated-14 MuiFormLabel-required-23 MuiInputLabel-required-9"
+          data-shrink="false"
+          for="best"
+        >
+          Test
+          <span
+            class="MuiFormLabel-asterisk-24 MuiInputLabel-asterisk-10"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root-50 MuiOutlinedInput-root-35 MuiInputBase-formControl-51"
+        >
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby=" mui-component-select-best"
+            class="MuiSelect-root-25 MuiSelect-select-26 MuiSelect-selectMenu-29 MuiSelect-outlined-28 MuiInputBase-input-61 MuiOutlinedInput-input-45"
+            id="mui-component-select-best"
+            role="button"
+            tabindex="0"
+          >
+            Bar
+          </div>
+          <input
+            name="best"
+            type="hidden"
+            value="bar"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root-68 MuiSelect-icon-31 MuiSelect-iconOutlined-34"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="PrivateNotchedOutline-root-81 MuiOutlinedInput-notchedOutline-44"
+            style="padding-left: 8px;"
+          >
+            <legend
+              class="PrivateNotchedOutline-legend-82"
+              style="width: 0.01px;"
+            >
+              <span>
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Select basic component renders outlined without a label 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <form
+        data-testid="form"
+        novalidate=""
+      >
+        <div
+          class="MuiFormControl-root-1 MuiFormControl-marginNormal-2 MuiFormControl-fullWidth-4"
+        >
+          <div
+            class="MuiInputBase-root-30 MuiOutlinedInput-root-15 MuiInputBase-formControl-31"
+          >
+            <div
+              aria-haspopup="listbox"
+              aria-labelledby=" mui-component-select-best"
+              class="MuiSelect-root-5 MuiSelect-select-6 MuiSelect-selectMenu-9 MuiSelect-outlined-8 MuiInputBase-input-41 MuiOutlinedInput-input-25"
+              id="mui-component-select-best"
+              role="button"
+              tabindex="0"
+            >
+              Bar
+            </div>
+            <input
+              name="best"
+              type="hidden"
+              value="bar"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-48 MuiSelect-icon-11 MuiSelect-iconOutlined-14"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root-61 MuiOutlinedInput-notchedOutline-24"
+              style="padding-left: 8px;"
+            >
+              <legend
+                class="PrivateNotchedOutline-legend-62"
+                style="width: 0.01px;"
+              >
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      data-testid="form"
+      novalidate=""
+    >
+      <div
+        class="MuiFormControl-root-1 MuiFormControl-marginNormal-2 MuiFormControl-fullWidth-4"
+      >
+        <div
+          class="MuiInputBase-root-30 MuiOutlinedInput-root-15 MuiInputBase-formControl-31"
+        >
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby=" mui-component-select-best"
+            class="MuiSelect-root-5 MuiSelect-select-6 MuiSelect-selectMenu-9 MuiSelect-outlined-8 MuiInputBase-input-41 MuiOutlinedInput-input-25"
+            id="mui-component-select-best"
+            role="button"
+            tabindex="0"
+          >
+            Bar
+          </div>
+          <input
+            name="best"
+            type="hidden"
+            value="bar"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root-48 MuiSelect-icon-11 MuiSelect-iconOutlined-14"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="PrivateNotchedOutline-root-61 MuiOutlinedInput-notchedOutline-24"
+            style="padding-left: 8px;"
+          >
+            <legend
+              class="PrivateNotchedOutline-legend-62"
+              style="width: 0.01px;"
+            >
+              <span>
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Select basic component renders without errors 1`] = `
 Object {
   "asFragment": [Function],


### PR DESCRIPTION
Updated the Select component typings and the effect responsible for measuring label width to allow label=undefined.

Also added tests for rendering the component with and without a label, both with variant="outlined" (special case when the label needs measuring).

Closes #156