### PR TITLE
Adds/fixes onChange support for all fields

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,6 +1,6 @@
 import 'react-app-polyfill/ie11';
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 
 import {
@@ -214,7 +214,8 @@ const useFormStyles = makeStyles((theme: Theme) =>
 
 function MainForm({ subscription }: any) {
 	const classes = useFormStyles();
-	const [submittedValues, setSubmittedValues] = useState<FormData | undefined>(undefined);
+	const [submittedValues, setSubmittedValues] = useState<FormData>();
+	const [onFieldChangeValues, setOnFieldChangeValues] = useState<unknown>();
 
 	const autocompleteData: AutocompleteData[] = [
 		{ label: 'Earth', value: 'earth' },
@@ -249,8 +250,8 @@ function MainForm({ subscription }: any) {
 		{ label: 'Both', value: 'both' },
 	];
 
-	const initialValues: FormData = {
-		planet: [autocompleteData[1].value],
+	const makeInitialValues = (): FormData => ({
+		planet: ['mars'],
 		best: [],
 		switch: ['bar'],
 		available: false,
@@ -262,7 +263,10 @@ function MainForm({ subscription }: any) {
 		birthday: new Date('2014-08-18'),
 		break: new Date('2019-04-20T16:20:00'),
 		hidden: 'secret',
-	};
+	});
+
+	// whenever initialValues changes all fields will update to those values, so use useMemo or useState to prevent your changes being thrown away if this parent component rerenders
+	const [initialValues, setInitialValues] = useState(makeInitialValues());
 
 	const onSubmit = (values: FormData) => {
 		setSubmittedValues(values);
@@ -270,7 +274,12 @@ function MainForm({ subscription }: any) {
 
 	const onReset = () => {
 		setSubmittedValues(undefined);
+		setInitialValues(makeInitialValues());
 	};
+
+	const onFieldChange = useCallback((value: unknown, previousValue?: unknown) => {
+		setOnFieldChangeValues({ value, previousValue });
+	}, []);
 
 	const helperText = '* Required';
 
@@ -291,6 +300,7 @@ function MainForm({ subscription }: any) {
 				</>
 			)}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<Switches
 			label="Available"
@@ -298,6 +308,7 @@ function MainForm({ subscription }: any) {
 			required={required.available}
 			data={{ label: 'available', value: 'available' }}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<Switches
 			label="Check at least one..."
@@ -305,6 +316,7 @@ function MainForm({ subscription }: any) {
 			required={required.switch}
 			data={switchData}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<Checkboxes
 			label="Check at least one..."
@@ -312,6 +324,7 @@ function MainForm({ subscription }: any) {
 			required={required.best}
 			data={checkboxData}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<Radios
 			label="Pick a gender"
@@ -319,6 +332,7 @@ function MainForm({ subscription }: any) {
 			required={required.gender}
 			data={radioData}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<KeyboardDatePicker
 			label="Pick a date"
@@ -326,6 +340,7 @@ function MainForm({ subscription }: any) {
 			required={required.date}
 			dateFunsUtils={DateFnsUtils}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<DatePicker
 			label="Birthday"
@@ -333,6 +348,7 @@ function MainForm({ subscription }: any) {
 			required={required.birthday}
 			dateFunsUtils={DateFnsUtils}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<TimePicker
 			label="Break time"
@@ -340,8 +356,15 @@ function MainForm({ subscription }: any) {
 			required={required.break}
 			dateFunsUtils={DateFnsUtils}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
-		<TextField label="Hello world" name="hello" required={required.hello} helperText={helperText} />,
+		<TextField
+			label="Hello world"
+			name="hello"
+			required={required.hello}
+			helperText={helperText}
+			onChange={onFieldChange}
+		/>,
 		<TextField
 			label="Hidden text"
 			name="hidden"
@@ -349,6 +372,7 @@ function MainForm({ subscription }: any) {
 			autoComplete="new-password"
 			required={required.hidden}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 		<Select
 			label="Pick some cities..."
@@ -357,6 +381,7 @@ function MainForm({ subscription }: any) {
 			data={selectData}
 			multiple={true}
 			helperText="Woah helper text"
+			onChange={onFieldChange}
 		/>,
 		<Checkboxes
 			name="terms"
@@ -366,6 +391,7 @@ function MainForm({ subscription }: any) {
 				value: true,
 			}}
 			helperText={helperText}
+			onChange={onFieldChange}
 		/>,
 	];
 
@@ -373,7 +399,7 @@ function MainForm({ subscription }: any) {
 		<Paper className={classes.paper}>
 			<Form
 				onSubmit={onSubmit}
-				initialValues={submittedValues ? submittedValues : initialValues}
+				initialValues={initialValues}
 				subscription={subscription}
 				validate={validate}
 				key={subscription as any}
@@ -418,6 +444,20 @@ function MainForm({ subscription }: any) {
 										</Typography>
 										<pre>
 											{JSON.stringify(submittedValues ? submittedValues : {}, undefined, 2)}
+										</pre>
+									</Paper>
+								</Grid>
+								<Grid item>
+									<Paper className={classes.paperInner} elevation={3}>
+										<Typography>
+											<strong>Field onChange</strong>
+										</Typography>
+										<pre>
+											{JSON.stringify(
+												onFieldChangeValues ? onFieldChangeValues : {},
+												undefined,
+												2
+											)}
 										</pre>
 									</Paper>
 								</Grid>

--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, ReactNode } from 'react';
 
-import { Field, FieldRenderProps, FieldProps } from 'react-final-form';
+import { Field, FieldRenderProps, FieldProps, useForm } from 'react-final-form';
 
 import TextField, { TextFieldProps as MuiTextFieldProps } from '@material-ui/core/TextField';
 import {
@@ -17,6 +17,7 @@ export interface AutocompleteProps extends Partial<MuiAutocompleteProps<any>> {
 	name: string;
 	label: ReactNode;
 	helperText?: string;
+	onChange?: (value: MuiTextFieldProps['value'], previousValue: MuiTextFieldProps['value'] | undefined) => void;
 	required?: boolean;
 	multiple?: boolean;
 	getOptionValue?: (option: any) => any;
@@ -41,22 +42,26 @@ interface AutocompleteWrapperProps extends FieldRenderProps<MuiTextFieldProps, H
 	label: ReactNode;
 	required?: boolean;
 	multiple?: boolean;
+	onChange?: AutocompleteProps['onChange'];
 	textFieldProps?: Partial<MuiTextFieldProps>;
 	getOptionValue?: (option: any) => any;
 }
 
 const AutocompleteWrapper = (props: AutocompleteWrapperProps) => {
 	const {
-		input: { name, onChange, value, ...restInput },
+		input: { name, onChange: rffOnChange, value, ...restInput },
 		meta,
 		options,
 		label,
 		required,
 		multiple,
+		onChange,
 		textFieldProps,
 		getOptionValue,
 		...rest
 	} = props;
+
+	const { getFieldState } = useForm();
 
 	function getValue(values: any) {
 		if (!getOptionValue) {
@@ -100,12 +105,15 @@ const AutocompleteWrapper = (props: AutocompleteWrapperProps) => {
 		});
 	}
 
-	const onChangeFunc = (_e: ChangeEvent<{}>, values: any | any[] | null) => onChange(getValue(values));
-
 	return (
 		<MuiAutocomplete
 			multiple={multiple as any}
-			onChange={onChangeFunc}
+			onChange={(_e: ChangeEvent<{}>, values: any) => {
+				const value = getValue(values);
+				const previousValue = getFieldState(name)!.value;
+				rffOnChange(value);
+				if (onChange) onChange(value, previousValue);
+			}}
 			options={options}
 			value={defaultValue}
 			renderInput={(params: MuiAutocompleteRenderInputParams) => (

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@material-ui/pickers';
 
-import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
+import { Field, FieldProps, FieldRenderProps, useForm } from 'react-final-form';
 
 import pickerProviderWrapper from './PickerProvider';
 
-export interface DatePickerProps extends Partial<MuiDatePickerProps> {
+export interface DatePickerProps extends Partial<Omit<MuiDatePickerProps, 'onChange'>> {
 	dateFunsUtils?: any;
 	fieldProps?: Partial<FieldProps<any, any>>;
+	onChange?: (value: MuiDatePickerProps['value'], previousValue: MuiDatePickerProps['value'] | undefined) => void;
 }
 
 export function DatePicker(props: DatePickerProps) {
@@ -25,15 +26,19 @@ export function DatePicker(props: DatePickerProps) {
 
 interface DatePickerWrapperProps extends FieldRenderProps<MuiDatePickerProps, HTMLElement> {
 	dateFunsUtils?: any;
+	onChange?: DatePickerProps['onChange'];
 }
 
 function DatePickerWrapper(props: DatePickerWrapperProps) {
 	const {
-		input: { name, onChange, value, ...restInput },
+		input: { name, onChange: rffOnChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		onChange,
 		...rest
 	} = props;
+
+	const { getFieldState } = useForm();
 
 	const { helperText, ...lessrest } = rest;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
@@ -47,7 +52,11 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 			error={showError}
 			format="yyyy-MM-dd"
 			margin="normal"
-			onChange={onChange}
+			onChange={value => {
+				const previousValue = getFieldState(name)!.value;
+				rffOnChange(value);
+				if (onChange) onChange(getFieldState(name)!.value, previousValue);
+			}}
 			name={name}
 			value={(value as any) === '' ? null : value}
 			{...lessrest}

--- a/src/KeyboardDatePicker.tsx
+++ b/src/KeyboardDatePicker.tsx
@@ -5,13 +5,17 @@ import {
 	KeyboardDatePickerProps as MuiKeyboardDatePickerProps,
 } from '@material-ui/pickers';
 
-import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
+import { Field, FieldProps, FieldRenderProps, useForm } from 'react-final-form';
 
 import pickerProviderWrapper from './PickerProvider';
 
-export interface KeyboardDatePickerProps extends Partial<MuiKeyboardDatePickerProps> {
+export interface KeyboardDatePickerProps extends Partial<Omit<MuiKeyboardDatePickerProps, 'onSubmit'>> {
 	dateFunsUtils?: any;
 	fieldProps?: Partial<FieldProps<any, any>>;
+	onChange?: (
+		value: MuiKeyboardDatePickerProps['value'],
+		previousValue: MuiKeyboardDatePickerProps['value'] | undefined
+	) => void;
 }
 
 export function KeyboardDatePicker(props: KeyboardDatePickerProps) {
@@ -28,15 +32,19 @@ export function KeyboardDatePicker(props: KeyboardDatePickerProps) {
 
 interface DatePickerWrapperProps extends FieldRenderProps<MuiKeyboardDatePickerProps, HTMLElement> {
 	dateFunsUtils?: any;
+	onChange?: KeyboardDatePickerProps['onChange'];
 }
 
 function KeyboardDatePickerWrapper(props: DatePickerWrapperProps) {
 	const {
-		input: { name, onChange, value, ...restInput },
+		input: { name, onChange: rffOnChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		onChange,
 		...rest
 	} = props;
+
+	const { getFieldState } = useForm();
 
 	const { helperText, ...lessrest } = rest;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
@@ -52,7 +60,11 @@ function KeyboardDatePickerWrapper(props: DatePickerWrapperProps) {
 			variant="inline"
 			format="yyyy-MM-dd"
 			margin="normal"
-			onChange={onChange}
+			onChange={value => {
+				const previousValue = getFieldState(name)!.value;
+				rffOnChange(value);
+				if (onChange) onChange(getFieldState(name)!.value, previousValue);
+			}}
 			name={name}
 			value={(value as any) === '' ? null : value}
 			{...lessrest}

--- a/src/KeyboardTimePicker.tsx
+++ b/src/KeyboardTimePicker.tsx
@@ -5,13 +5,17 @@ import {
 	KeyboardTimePickerProps as MuiKeyboardTimePickerProps,
 } from '@material-ui/pickers';
 
-import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
+import { Field, FieldProps, FieldRenderProps, useForm } from 'react-final-form';
 
 import pickerProviderWrapper from './PickerProvider';
 
-export interface KeyboardTimePickerProps extends Partial<MuiKeyboardTimePickerProps> {
+export interface KeyboardTimePickerProps extends Partial<Omit<MuiKeyboardTimePickerProps, 'onChange'>> {
 	dateFunsUtils?: any;
 	fieldProps?: Partial<FieldProps<any, any>>;
+	onChange?: (
+		value: MuiKeyboardTimePickerProps['value'],
+		previousValue: MuiKeyboardTimePickerProps['value'] | undefined
+	) => void;
 }
 
 export function KeyboardTimePicker(props: KeyboardTimePickerProps) {
@@ -28,15 +32,19 @@ export function KeyboardTimePicker(props: KeyboardTimePickerProps) {
 
 interface KeyboardTimePickerWrapperProps extends FieldRenderProps<MuiKeyboardTimePickerProps, HTMLElement> {
 	dateFunsUtils?: any;
+	onChange?: KeyboardTimePickerProps['onChange'];
 }
 
 function KeyboardTimePickerWrapper(props: KeyboardTimePickerWrapperProps) {
 	const {
-		input: { name, onChange, value, ...restInput },
+		input: { name, onChange: rffOnChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		onChange,
 		...rest
 	} = props;
+
+	const { getFieldState } = useForm();
 
 	const { helperText, ...lessrest } = rest;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
@@ -49,7 +57,11 @@ function KeyboardTimePickerWrapper(props: KeyboardTimePickerWrapperProps) {
 			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
 			margin="normal"
-			onChange={onChange}
+			onChange={value => {
+				const previousValue = getFieldState(name)!.value;
+				rffOnChange(value);
+				if (onChange) onChange(getFieldState(name)!.value, previousValue);
+			}}
 			name={name}
 			value={(value as any) === '' ? null : value}
 			{...lessrest}

--- a/src/Radios.tsx
+++ b/src/Radios.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, ReactNode } from 'react';
 
 import {
 	Radio as MuiRadio,
-	RadioProps,
+	RadioProps as MuiRadioProps,
 	RadioGroup,
 	RadioGroupProps,
 	FormControl,
@@ -15,7 +15,7 @@ import {
 	FormLabelProps,
 } from '@material-ui/core';
 
-import { Field, FieldProps, useFormState } from 'react-final-form';
+import { Field, FieldProps, useFormState, useForm } from 'react-final-form';
 
 export interface RadioData {
 	label: ReactNode;
@@ -23,12 +23,13 @@ export interface RadioData {
 	disabled?: boolean;
 }
 
-export interface RadiosProps extends Partial<RadioProps> {
+export interface RadiosProps extends Partial<Omit<MuiRadioProps, 'onChange'>> {
 	name: string;
 	data: RadioData[];
 	label?: ReactNode;
 	required?: boolean;
 	helperText?: string;
+	onChange?: (value: MuiRadioProps['value'], previousValue: MuiRadioProps['value'] | undefined) => void;
 	formLabelProps?: Partial<FormLabelProps>;
 	formControlLabelProps?: Partial<FormControlLabelProps>;
 	fieldProps?: Partial<FieldProps<any, any>>;
@@ -44,6 +45,7 @@ export function Radios(props: RadiosProps) {
 		label,
 		required,
 		helperText,
+		onChange,
 		formLabelProps,
 		formControlLabelProps,
 		fieldProps,
@@ -53,8 +55,8 @@ export function Radios(props: RadiosProps) {
 		...restRadios
 	} = props;
 
-	const formState = useFormState();
-	const { errors, submitErrors, submitFailed, modified } = formState;
+	const { errors, submitErrors, submitFailed, modified } = useFormState();
+	const { getFieldState } = useForm();
 	const [errorState, setErrorState] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -75,11 +77,15 @@ export function Radios(props: RadiosProps) {
 						disabled={item.disabled}
 						control={
 							<Field type="radio" name={name} {...fieldProps}>
-								{({ input: { name, value, onChange, checked, ...restInput } }) => (
+								{({ input: { name, value, onChange: rffOnChange, checked, ...restInput } }) => (
 									<MuiRadio
 										name={name}
 										value={value}
-										onChange={onChange}
+										onChange={e => {
+											const previousValue = getFieldState(name)!.value;
+											rffOnChange(e);
+											if (onChange) onChange(getFieldState(name)!.value, previousValue);
+										}}
 										checked={checked}
 										inputProps={{ required: required, ...restInput }}
 										{...restRadios}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -13,20 +13,21 @@ import {
 	MenuItemProps,
 } from '@material-ui/core';
 
-import { Field, FieldProps, useFormState } from 'react-final-form';
+import { Field, FieldProps, useFormState, useForm } from 'react-final-form';
 
 export interface SelectData {
 	label: string;
-	value: string;
+	value: any;
 	disabled?: boolean;
 }
 
-export interface SelectProps extends Partial<MuiSelectProps> {
+export interface SelectProps extends Omit<MuiSelectProps, 'onChange'> {
 	name: string;
 	label: ReactNode;
 	required?: boolean;
 	multiple?: boolean;
 	helperText?: string;
+	onChange?: (value: SelectData['value'], previousValue: SelectData['value'] | undefined) => void;
 	fieldProps?: Partial<FieldProps<any, any>>;
 	formControlProps?: Partial<FormControlProps>;
 	inputLabelProps?: Partial<InputLabelProps>;
@@ -45,6 +46,7 @@ export function Select(props: SelectProps) {
 		required,
 		multiple,
 		helperText,
+		onChange,
 		fieldProps,
 		inputLabelProps,
 		formControlProps,
@@ -58,8 +60,8 @@ export function Select(props: SelectProps) {
 		throw new Error('Please specify either children or data as an attribute.');
 	}
 
-	const formState = useFormState();
-	const { errors, submitErrors, submitFailed, modified } = formState;
+	const { errors, submitErrors, submitFailed, modified } = useFormState();
+	const { getFieldState } = useForm();
 	const [errorState, setErrorState] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -84,11 +86,15 @@ export function Select(props: SelectProps) {
 				</InputLabel>
 			)}
 			<Field name={name} {...fieldProps}>
-				{({ input: { name, value, onChange, ...restInput } }) => (
+				{({ input: { name, value, onChange: rffOnChange, ...restInput } }) => (
 					<MuiSelect
 						name={name}
 						value={value}
-						onChange={onChange}
+						onChange={e => {
+							const previousValue = getFieldState(name)!.value;
+							rffOnChange(e);
+							if (onChange) onChange(getFieldState(name)!.value, previousValue);
+						}}
 						multiple={multiple}
 						labelWidth={variant === 'outlined' ? labelWidthState : labelWidth}
 						inputProps={{ required: required, ...restInput }}

--- a/src/Switches.tsx
+++ b/src/Switches.tsx
@@ -15,20 +15,21 @@ import {
 	FormLabelProps,
 } from '@material-ui/core';
 
-import { Field, FieldProps, useFormState } from 'react-final-form';
+import { Field, FieldProps, useFormState, useForm } from 'react-final-form';
 
 export interface SwitchData {
 	label: ReactNode;
-	value: any;
+	value: unknown;
 	disabled?: boolean;
 }
 
-export interface SwitchesProps extends Partial<MuiSwitchProps> {
+export interface SwitchesProps extends Partial<Omit<MuiSwitchProps, 'onChange'>> {
 	name: string;
 	data: SwitchData | SwitchData[];
 	label?: ReactNode;
 	required?: boolean;
 	helperText?: string;
+	onChange?: (value: SwitchData['value'][], previousValue: SwitchData['value'][] | undefined) => void;
 	fieldProps?: Partial<FieldProps<any, any>>;
 	formControlProps?: Partial<FormControlProps>;
 	formGroupProps?: Partial<FormGroupProps>;
@@ -44,6 +45,7 @@ export function Switches(props: SwitchesProps) {
 		label,
 		required,
 		helperText,
+		onChange,
 		fieldProps,
 		formControlProps,
 		formGroupProps,
@@ -53,8 +55,8 @@ export function Switches(props: SwitchesProps) {
 		...restSwitches
 	} = props;
 
-	const formState = useFormState();
-	const { errors, submitErrors, submitFailed, modified } = formState;
+	const { errors, submitErrors, submitFailed, modified } = useFormState();
+	const { getFieldState } = useForm();
 	const [errorState, setErrorState] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -62,20 +64,14 @@ export function Switches(props: SwitchesProps) {
 		setErrorState(showError ? errors[name] || submitErrors[name] : null);
 	}, [errors, submitErrors, submitFailed, modified, name]);
 
-	const isArray = Array.isArray(data);
-	const single = !isArray || (isArray && (data as any).length === 1);
-
-	// This works around the fact that we can pass in a single item
-	let itemData = data;
-	if (!isArray) {
-		itemData = [data] as any;
-	}
+	const itemsData = !Array.isArray(data) ? [data] : data;
+	const single = itemsData.length === 1;
 
 	return (
 		<FormControl required={required} error={!!errorState} margin="normal" {...formControlProps}>
 			{label ? <FormLabel {...formLabelProps}>{label}</FormLabel> : <></>}
 			<FormGroup {...formGroupProps}>
-				{(itemData as any).map((item: SwitchData, idx: number) => (
+				{itemsData.map((item: SwitchData, idx: number) => (
 					<FormControlLabel
 						key={idx}
 						name={name}
@@ -84,11 +80,15 @@ export function Switches(props: SwitchesProps) {
 						disabled={item.disabled}
 						control={
 							<Field type="checkbox" name={name} {...fieldProps}>
-								{({ input: { name, value, onChange, checked, ...restInput } }) => (
+								{({ input: { name, value, onChange: rffOnChange, checked, ...restInput } }) => (
 									<MuiSwitch
 										name={name}
 										value={value}
-										onChange={onChange}
+										onChange={e => {
+											const previousValue = getFieldState(name)!.value;
+											rffOnChange(e);
+											if (onChange) onChange(getFieldState(name)!.value, previousValue);
+										}}
 										checked={checked}
 										inputProps={{ required: required, ...restInput }}
 										{...restSwitches}

--- a/src/TimePicker.tsx
+++ b/src/TimePicker.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import { TimePicker as MuiTimePicker, TimePickerProps as MuiTimePickerProps } from '@material-ui/pickers';
 
-import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
+import { Field, FieldProps, FieldRenderProps, useForm } from 'react-final-form';
 
 import pickerProviderWrapper from './PickerProvider';
 
-export interface TimePickerProps extends Partial<MuiTimePickerProps> {
+export interface TimePickerProps extends Partial<Omit<MuiTimePickerProps, 'onChange'>> {
 	dateFunsUtils?: any;
 	fieldProps?: Partial<FieldProps<any, any>>;
+	onChange?: (value: unknown, previousValue: unknown) => void;
 }
 
 export function TimePicker(props: TimePickerProps) {
@@ -25,15 +26,19 @@ export function TimePicker(props: TimePickerProps) {
 
 interface TimePickerWrapperProps extends FieldRenderProps<MuiTimePickerProps, HTMLElement> {
 	dateFunsUtils?: any;
+	onChange?: TimePickerProps['onChange'];
 }
 
 function TimePickerWrapper(props: TimePickerWrapperProps) {
 	const {
-		input: { name, onChange, value, ...restInput },
+		input: { name, onChange: rffOnChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		onChange,
 		...rest
 	} = props;
+
+	const { getFieldState } = useForm();
 
 	const { helperText, ...lessrest } = rest;
 	const showError = ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
@@ -46,7 +51,11 @@ function TimePickerWrapper(props: TimePickerWrapperProps) {
 			helperText={showError ? meta.error || meta.submitError : helperText}
 			error={showError}
 			margin="normal"
-			onChange={onChange}
+			onChange={value => {
+				const previousValue = getFieldState(name)!.value;
+				rffOnChange(value);
+				if (onChange) onChange(getFieldState(name)!.value, previousValue);
+			}}
 			name={name}
 			value={(value as any) === '' ? null : value}
 			{...lessrest}


### PR DESCRIPTION
Adds the ability to pass `onChange={(value, previousValue) => { console.log("field value changed", { value, previousValue }) }}` to all fields. `onChange` is supported by a lot of the fields at the moment (because of extending MUI field prop interfaces), but passing anything in breaks the inputs as it stops RFF from passing in its own function to control the form state. This fixes those problems.

I've also added it into the examples document, and ran eslint. However, I haven't added any tests so I imagine it *may* block approval, even though it fixes the existing onChange RFF override bug.