### PR TITLE
Properly set disabled attribute on actual checkbox/radio/switch

### DIFF
--- a/src/Checkboxes.tsx
+++ b/src/Checkboxes.tsx
@@ -84,6 +84,7 @@ export function Checkboxes(props: CheckboxesProps) {
 										value={value}
 										onChange={onChange}
 										checked={checked}
+										disabled={item.disabled}
 										inputProps={{ required: required, ...restInput }}
 										{...restCheckboxes}
 									/>

--- a/src/Radios.tsx
+++ b/src/Radios.tsx
@@ -81,6 +81,7 @@ export function Radios(props: RadiosProps) {
 										value={value}
 										onChange={onChange}
 										checked={checked}
+										disabled={item.disabled}
 										inputProps={{ required: required, ...restInput }}
 										{...restRadios}
 									/>

--- a/src/Switches.tsx
+++ b/src/Switches.tsx
@@ -84,6 +84,7 @@ export function Switches(props: SwitchesProps) {
 										value={value}
 										onChange={onChange}
 										checked={checked}
+										disabled={item.disabled}
 										inputProps={{ required: required, ...restInput }}
 										{...restSwitches}
 									/>

--- a/test/Checkboxes.test.tsx
+++ b/test/Checkboxes.test.tsx
@@ -161,6 +161,32 @@ describe('Checkboxes', () => {
 				expect(rendered).toMatchSnapshot();
 			});
 		});
+
+		it('has mui checkboxes disabled', async () => {
+			await act(async () => {
+				const rendered = render(
+					<CheckboxComponent
+						data={[
+							{
+								label: 'Bar',
+								value: 'bar',
+								disabled: true,
+							},
+							{
+								label: 'Foo',
+								value: 'foo',
+								disabled: false,
+							},
+						]}
+						initialValues={initialValues}
+					/>
+				);
+				const inputs = rendered.getAllByRole('checkbox') as HTMLInputElement[];
+				expect(inputs.length).toBe(2);
+				expect(inputs[0].disabled).toBe(true);
+				expect(inputs[1].disabled).toBe(false);
+			});
+		});
 	});
 
 	describe('submit button tests', () => {

--- a/test/Radios.test.tsx
+++ b/test/Radios.test.tsx
@@ -154,6 +154,32 @@ describe('Radios', () => {
 
 			expect(container).toMatchSnapshot();
 		});
+
+		it('has mui radios disabled', async () => {
+			await act(async () => {
+				const rendered = render(
+					<RadioComponent
+						data={[
+							{
+								label: 'Bar',
+								value: 'bar',
+								disabled: true,
+							},
+							{
+								label: 'Foo',
+								value: 'foo',
+								disabled: false,
+							},
+						]}
+						initialValues={initialValues}
+					/>
+				);
+				const inputs = rendered.getAllByRole('radio') as HTMLInputElement[];
+				expect(inputs.length).toBe(2);
+				expect(inputs[0].disabled).toBe(true);
+				expect(inputs[1].disabled).toBe(false);
+			});
+		});
 	});
 
 	describe('errors on submit', () => {

--- a/test/Switches.test.tsx
+++ b/test/Switches.test.tsx
@@ -163,6 +163,32 @@ describe('Switches', () => {
 				expect(rendered).toMatchSnapshot();
 			});
 		});
+
+		it('has mui switches disabled', async () => {
+			await act(async () => {
+				const rendered = render(
+					<SwitchComponent
+						data={[
+							{
+								label: 'Bar',
+								value: 'bar',
+								disabled: true,
+							},
+							{
+								label: 'Foo',
+								value: 'foo',
+								disabled: false,
+							},
+						]}
+						initialValues={initialValues}
+					/>
+				);
+				const inputs = rendered.getAllByRole('checkbox') as HTMLInputElement[];
+				expect(inputs.length).toBe(2);
+				expect(inputs[0].disabled).toBe(true);
+				expect(inputs[1].disabled).toBe(false);
+			});
+		});
 	});
 
 	describe('submit button tests', () => {


### PR DESCRIPTION
While working with checkboxes today, I noticed that even though I disabled specific options, they were only visually disabled, but I could still check/uncheck them.

This PR fixes that for both checkboxes, radios and switches.