### PR TITLE
Optimize error handling for input groups

### DIFF
--- a/src/Checkboxes.tsx
+++ b/src/Checkboxes.tsx
@@ -1,21 +1,20 @@
-import React, { useState, useEffect, ReactNode, Dispatch, SetStateAction } from 'react';
-
 import {
 	Checkbox as MuiCheckbox,
 	CheckboxProps as MuiCheckboxProps,
 	FormControl,
-	FormControlProps,
 	FormControlLabel,
 	FormControlLabelProps,
+	FormControlProps,
 	FormGroup,
 	FormGroupProps,
 	FormHelperTextProps,
 	FormLabel,
 	FormLabelProps,
 } from '@material-ui/core';
+import React, { ReactNode } from 'react';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
-import { ErrorMessage, ErrorState, makeErrorEffect } from './Util';
+import { ErrorMessage, showError, useFieldForErrors } from './Util';
 
 export interface CheckboxData {
 	label: ReactNode;
@@ -53,13 +52,13 @@ export function Checkboxes(props: CheckboxesProps) {
 		...restCheckboxes
 	} = props;
 
-	const [errorState, setErrorState] = useState<ErrorState>({ showError: false });
-
 	const itemsData = !Array.isArray(data) ? [data] : data;
 	const single = itemsData.length === 1;
+	const field = useFieldForErrors(name);
+	const isError = showError(field);
 
 	return (
-		<FormControl required={required} error={errorState.showError} {...formControlProps}>
+		<FormControl required={required} error={isError} {...formControlProps}>
 			{label ? <FormLabel {...formLabelProps}>{label}</FormLabel> : <></>}
 			<FormGroup {...formGroupProps}>
 				{itemsData.map((item: CheckboxData, idx: number) => (
@@ -77,7 +76,6 @@ export function Checkboxes(props: CheckboxesProps) {
 									<MuiCheckboxWrapperField
 										input={input}
 										meta={meta}
-										setError={setErrorState}
 										required={required}
 										disabled={item.disabled}
 										helperText={helperText}
@@ -91,14 +89,17 @@ export function Checkboxes(props: CheckboxesProps) {
 					/>
 				))}
 			</FormGroup>
-			<ErrorMessage errorState={errorState} formHelperTextProps={formHelperTextProps} helperText={helperText} />
+			<ErrorMessage
+				showError={isError}
+				meta={field.meta}
+				formHelperTextProps={formHelperTextProps}
+				helperText={helperText}
+			/>
 		</FormControl>
 	);
 }
 
-interface MuiCheckboxWrapperFieldProps extends FieldRenderProps<Partial<MuiCheckboxProps>, HTMLElement> {
-	setError: Dispatch<SetStateAction<ErrorState>>;
-}
+interface MuiCheckboxWrapperFieldProps extends FieldRenderProps<Partial<MuiCheckboxProps>, HTMLElement> {}
 
 function MuiCheckboxWrapperField(props: MuiCheckboxWrapperFieldProps) {
 	const {
@@ -106,11 +107,8 @@ function MuiCheckboxWrapperField(props: MuiCheckboxWrapperFieldProps) {
 		meta,
 		helperText,
 		required,
-		setError,
 		...restCheckboxes
 	} = props;
-
-	useEffect.apply(useEffect, makeErrorEffect({ meta, helperText, setError }) as any);
 
 	return (
 		<MuiCheckbox

--- a/src/Radios.tsx
+++ b/src/Radios.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, ReactNode, Dispatch, SetStateAction } from 'react';
+import React, { ReactNode } from 'react';
 
 import {
 	Radio as MuiRadio,
@@ -15,7 +15,7 @@ import {
 } from '@material-ui/core';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
-import { ErrorMessage, ErrorState, makeErrorEffect } from './Util';
+import { ErrorMessage, showError, useFieldForErrors } from './Util';
 
 export interface RadioData {
 	label: ReactNode;
@@ -53,10 +53,11 @@ export function Radios(props: RadiosProps) {
 		...restRadios
 	} = props;
 
-	const [errorState, setErrorState] = useState<ErrorState>({ showError: false });
+	const field = useFieldForErrors(name);
+	const isError = showError(field);
 
 	return (
-		<FormControl required={required} error={errorState.showError} {...formControlProps}>
+		<FormControl required={required} error={isError} {...formControlProps}>
 			{!!label && <FormLabel {...formLabelProps}>{label}</FormLabel>}
 			<RadioGroup {...radioGroupProps}>
 				{data.map((item: RadioData, idx: number) => (
@@ -74,7 +75,6 @@ export function Radios(props: RadiosProps) {
 									<MuiRadioWrapper
 										input={input}
 										meta={meta}
-										setError={setErrorState}
 										required={required}
 										disabled={item.disabled}
 										helperText={helperText}
@@ -88,14 +88,17 @@ export function Radios(props: RadiosProps) {
 					/>
 				))}
 			</RadioGroup>
-			<ErrorMessage errorState={errorState} formHelperTextProps={formHelperTextProps} helperText={helperText} />
+			<ErrorMessage
+				showError={isError}
+				meta={field.meta}
+				formHelperTextProps={formHelperTextProps}
+				helperText={helperText}
+			/>
 		</FormControl>
 	);
 }
 
-interface MuiRadioWrapperProps extends FieldRenderProps<Partial<MuiRadioProps>, HTMLInputElement> {
-	setError: Dispatch<SetStateAction<ErrorState>>;
-}
+interface MuiRadioWrapperProps extends FieldRenderProps<Partial<MuiRadioProps>, HTMLInputElement> {}
 
 function MuiRadioWrapper(props: MuiRadioWrapperProps) {
 	const {
@@ -103,11 +106,8 @@ function MuiRadioWrapper(props: MuiRadioWrapperProps) {
 		meta,
 		helperText,
 		required,
-		setError,
 		...rest
 	} = props;
-
-	useEffect.apply(useEffect, makeErrorEffect({ meta, helperText, setError }) as any);
 
 	return (
 		<MuiRadio

--- a/src/Switches.tsx
+++ b/src/Switches.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactNode, Dispatch, SetStateAction } from 'react';
+import React, { ReactNode } from 'react';
 
 import {
 	Switch as MuiSwitch,
@@ -15,7 +15,7 @@ import {
 } from '@material-ui/core';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
-import { ErrorMessage, ErrorState, makeErrorEffect } from './Util';
+import { ErrorMessage, showError, useFieldForErrors } from './Util';
 
 export interface SwitchData {
 	label: ReactNode;
@@ -53,13 +53,13 @@ export function Switches(props: SwitchesProps) {
 		...restSwitches
 	} = props;
 
-	const [errorState, setErrorState] = useState<ErrorState>({ showError: false });
-
 	const itemsData = !Array.isArray(data) ? [data] : data;
 	const single = itemsData.length === 1;
+	const field = useFieldForErrors(name);
+	const isError = showError(field);
 
 	return (
-		<FormControl required={required} error={errorState.showError} {...formControlProps}>
+		<FormControl required={required} error={isError} {...formControlProps}>
 			{label ? <FormLabel {...formLabelProps}>{label}</FormLabel> : <></>}
 			<FormGroup {...formGroupProps}>
 				{itemsData.map((item: SwitchData, idx: number) => (
@@ -77,7 +77,6 @@ export function Switches(props: SwitchesProps) {
 									<MuiSwitchWrapper
 										input={input}
 										meta={meta}
-										setError={setErrorState}
 										required={required}
 										disabled={item.disabled}
 										helperText={helperText}
@@ -91,14 +90,17 @@ export function Switches(props: SwitchesProps) {
 					/>
 				))}
 			</FormGroup>
-			<ErrorMessage errorState={errorState} formHelperTextProps={formHelperTextProps} helperText={helperText} />
+			<ErrorMessage
+				showError={isError}
+				meta={field.meta}
+				formHelperTextProps={formHelperTextProps}
+				helperText={helperText}
+			/>
 		</FormControl>
 	);
 }
 
-interface MuiSwitchWrapperProps extends FieldRenderProps<Partial<MuiSwitchProps>, HTMLInputElement> {
-	setError: Dispatch<SetStateAction<ErrorState>>;
-}
+interface MuiSwitchWrapperProps extends FieldRenderProps<Partial<MuiSwitchProps>, HTMLInputElement> {}
 
 function MuiSwitchWrapper(props: MuiSwitchWrapperProps) {
 	const {
@@ -106,11 +108,8 @@ function MuiSwitchWrapper(props: MuiSwitchWrapperProps) {
 		meta,
 		helperText,
 		required,
-		setError,
 		...rest
 	} = props;
-
-	useEffect.apply(useEffect, makeErrorEffect({ meta, helperText, setError }) as any);
 
 	return (
 		<MuiSwitch

--- a/src/Util.tsx
+++ b/src/Util.tsx
@@ -1,22 +1,18 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 
 import { FormHelperText, FormHelperTextProps } from '@material-ui/core';
-import { FieldMetaState } from 'react-final-form';
-
-export interface ErrorState {
-	showError: boolean;
-	message?: string;
-}
+import { FieldMetaState, useField } from 'react-final-form';
 
 export interface ErrorMessageProps {
-	errorState: ErrorState;
+	showError: boolean;
+	meta: FieldMetaState<any>;
 	formHelperTextProps?: Partial<FormHelperTextProps>;
 	helperText?: string;
 }
 
-export function ErrorMessage({ errorState, formHelperTextProps, helperText }: ErrorMessageProps) {
-	if (errorState.showError) {
-		return <FormHelperText {...formHelperTextProps}>{errorState.message}</FormHelperText>;
+export function ErrorMessage({ showError, meta, formHelperTextProps, helperText }: ErrorMessageProps) {
+	if (showError) {
+		return <FormHelperText {...formHelperTextProps}>{meta.error || meta.submitError}</FormHelperText>;
 	} else if (!!helperText) {
 		return <FormHelperText {...formHelperTextProps}>{helperText}</FormHelperText>;
 	} else {
@@ -24,30 +20,22 @@ export function ErrorMessage({ errorState, formHelperTextProps, helperText }: Er
 	}
 }
 
-export interface makeErrorEffectProps {
-	meta: FieldMetaState<any>;
-	setError: Dispatch<SetStateAction<ErrorState>>;
-	helperText?: string;
-}
-
-export function makeErrorEffect({
-	meta: { submitError, dirtySinceLastSubmit, error, touched, modified },
-	setError,
-	helperText,
-}: makeErrorEffectProps) {
-	return [
-		() => {
-			const showError = !!(((submitError && !dirtySinceLastSubmit) || error) && (touched || modified));
-			setError({ showError: showError, message: showError ? error || submitError : helperText });
-		},
-		[setError, submitError, dirtySinceLastSubmit, error, touched, helperText, modified],
-	];
-}
-
 export interface showErrorProps {
 	meta: FieldMetaState<any>;
 }
 
+export function useFieldForErrors(name: string) {
+	return useField(name, {
+		subscription: {
+			error: true,
+			submitError: true,
+			dirtySinceLastSubmit: true,
+			touched: true,
+			modified: true,
+		},
+	});
+}
+
 export function showError({ meta: { submitError, dirtySinceLastSubmit, error, touched, modified } }: showErrorProps) {
-	return ((submitError && !dirtySinceLastSubmit) || error) && (touched || modified);
+	return Boolean(((submitError && !dirtySinceLastSubmit) || error) && (touched || modified));
 }


### PR DESCRIPTION
As discusses, here's my recommendation for better error handling, so we don't need `useState` to set errors from within (which would actually trigger for every single checkbox/radio individually). Instead we can make use of `useField` here, while only subscribing to the necessary changes.

Side note: I received some errors at local testing about the Autocomplete component, which I didn't touch though. For some reason, Typescript resolves the props only to `UseAutocompleteMultipleProps`, so it always expects `multiple` to be `true`. No idea what's going on there.