### PR TITLE
translator function for makeValidate (closes #190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,44 @@ const validate = makeValidate(schema);
 </Form>
 ```
 
+## makeValidate(schema, translator)
+Yup [can be configured](https://github.com/jquense/yup#using-a-custom-locale-dictionary) to have a custom locale for when you need to translate your error messages or just general need more control. `makeValidate` accepts a second argument which is a `translator` which can return a `string` or a `JSX.Element`. So it can also be used if you have multiple errors and want to display them nicely via css (or e.g hide the second)
+
+```tsx
+import { Form } from 'react-final-form';
+import { makeValidate } from 'mui-rff';
+import * as Yup from 'yup';
+
+import t from 'some-kind-of-internationalization-library-like-i18next';
+
+
+// setup your locale and pass whatever your translator could use
+Yup.setLocale({
+  mixed: {
+		required: (props) => ({
+			key: 'field_required',
+			...props
+		}),
+  },
+})
+
+// We define our schema based on the same keys as our form:
+const schema = Yup.object().shape({
+  employed: Yup.boolean().required(),
+});
+
+// Run the makeValidate function...
+const validate = makeValidate(
+  schema
+  (error) => {
+    const {field, ...rest} = error;
+    return <span className='error'>{t(`errors:${error.field}`, rest)}</span>
+  }
+);
+
+```
+
+
 ## makeValidateSync(schema)
 
 Same as `makeValidate` but synchronous.

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
-    "testw": "tsdx test --watch -t Validate",
+    "testw": "tsdx test --watch",
     "lint": "tsdx lint src test --ignore-pattern node_modules",
     "lint-fix": "yarn lint --fix",
     "ui": "yarn upgradeInteractive; cd example; yarn ui; yarn upgrade",
     "predeploy": "cd example; yarn; yarn build",
     "deploy": "gh-pages -d example/dist",
     "prepublish": "yarn build",
-    "prepare": "yarn build",
     "postpublish": "yarn deploy"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "predeploy": "cd example; yarn; yarn build",
     "deploy": "gh-pages -d example/dist",
     "prepublish": "yarn build",
+    "prepare": "yarn build",
     "postpublish": "yarn deploy"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
+    "testw": "tsdx test --watch -t Validate",
     "lint": "tsdx lint src test --ignore-pattern node_modules",
     "lint-fix": "yarn lint --fix",
     "ui": "yarn upgradeInteractive; cd example; yarn ui; yarn upgrade",

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -38,7 +38,9 @@ interface ValidationError {
 }
 
 function normalizeValidationError(err: YupValidationError): ValidationError {
+	console.error('normalizeValidationError', err);
 	return err.inner.reduce((errors, { path, message }) => {
+		console.log('Handling..', errors, path, message);
 		if (errors.hasOwnProperty(path)) {
 			set(errors, path, get(errors, path) + ' ' + message);
 		} else {
@@ -53,6 +55,7 @@ function normalizeValidationError(err: YupValidationError): ValidationError {
  * where the key is the form field and the value is the error string.
  */
 export function makeValidate<T>(validator: YupSchema<T>) {
+	console.error('Make Validators...');
 	return async (values: T): Promise<ValidationError> => {
 		try {
 			await validator.validate(values, { abortEarly: false });

--- a/test/Validate.test.tsx
+++ b/test/Validate.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+
+import { Form } from 'react-final-form';
+import * as Yup from 'yup';
+
+import { makeValidate, TextField } from '../src';
+import { customRender, fireEvent, getNodeText } from './TestUtils';
+import { Translator } from '../src/Validation';
+
+type MyCustomError = Record<'key' | 'field', string>;
+
+Yup.setLocale({
+	mixed: {
+		required: ({ path }) => ({
+			key: 'field_required',
+			field: path,
+		}),
+	},
+	string: {
+		min: ({ path }) => ({
+			key: 'field_too_short',
+			field: path,
+		}),
+		email: ({ path }) => ({
+			key: 'field_not_email',
+			field: path,
+		}),
+	},
+});
+
+const myTranslatorFunction: Translator = (error: MyCustomError) => {
+	// use some kind of translation library to actually translate the objects to strings (like i18next)
+	return `${error.key}: ${error.field}`;
+};
+
+const myExtendedTranslatorFunction: Translator = (error: MyCustomError) => {
+	// use some kind of translation library to actually translate the objects to strings (like i18next)
+	return (
+		<span data-testid="error_field" key={error.key}>
+			{error.key}: {error.field}
+		</span>
+	);
+};
+
+interface ComponentProps {
+	initialValues: FormData;
+	validator?: any;
+	onSubmit?: any;
+}
+
+interface FormData {
+	hello: string;
+}
+
+describe('Validate', () => {
+	describe('multiple validation errors', () => {
+		const initialValues: FormData = {
+			hello: '',
+		};
+
+		function TextFieldComponent({ initialValues, validator }: ComponentProps) {
+			const onSubmit = (values: FormData) => {
+				console.log(values);
+			};
+
+			const validate = async (values: FormData) => {
+				if (validator) {
+					return validator(values);
+				}
+			};
+
+			return (
+				<Form
+					onSubmit={onSubmit}
+					initialValues={initialValues}
+					validate={validate}
+					render={({ handleSubmit }) => (
+						<form onSubmit={handleSubmit} noValidate>
+							<TextField
+								label="Test"
+								name="hello"
+								required={true}
+								inputProps={{ 'data-testid': 'textfield' }}
+							/>
+						</form>
+					)}
+				/>
+			);
+		}
+
+		it('with YUP localisation mingles objects when no translator', async () => {
+			const validateSchema = makeValidate(
+				Yup.object().shape({
+					hello: Yup.string()
+						.required()
+						.min(10)
+						.email(),
+				})
+			);
+
+			const dataFaulty = {
+				hello: '',
+			};
+
+			const errors = await validateSchema(dataFaulty);
+
+			expect(errors).toEqual({ hello: ['[object Object]', '[object Object]'] });
+		});
+
+		it('with YUP localisation doesnt mingle objects with a translator', async () => {
+			const validateSchema = makeValidate(
+				Yup.object().shape({
+					hello: Yup.string()
+						.required()
+						.min(10)
+						.email(),
+				}),
+				myTranslatorFunction
+			);
+
+			const dataFaulty = {
+				hello: '',
+			};
+
+			const errors = await validateSchema(dataFaulty);
+
+			expect(errors).toEqual({ hello: ['field_required: hello', 'field_too_short: hello'] });
+		});
+
+		it('can render multiple errors', async () => {
+			const message = 'field_too_short: hellofield_not_email: hello';
+
+			const validateSchema = makeValidate(
+				Yup.object().shape({
+					hello: Yup.string()
+						.required()
+						.min(10)
+						.email(),
+				}),
+				myTranslatorFunction
+			);
+
+			const { findByText, container } = customRender(
+				<TextFieldComponent validator={validateSchema} initialValues={initialValues} />
+			);
+			const input = container.querySelector('input') as HTMLInputElement;
+
+			// ensure the validation is made and errors are rendered
+			fireEvent.focus(input);
+			fireEvent.change(input, {
+				target: { value: 'no email' },
+			});
+			fireEvent.blur(input);
+
+			// find element with errors
+			const error = await findByText(/field_not_email/); // validation is async, so we have to await
+			expect(error.innerHTML).toContain(message);
+
+			expect(container).toMatchSnapshot();
+		});
+
+		it('can render multiple errors in seperate elements', async () => {
+			const validateSchema = makeValidate(
+				Yup.object().shape({
+					hello: Yup.string()
+						.required()
+						.min(10)
+						.email(),
+				}),
+				myExtendedTranslatorFunction
+			);
+
+			const { findAllByTestId, container } = customRender(
+				<TextFieldComponent validator={validateSchema} initialValues={initialValues} />
+			);
+			const input = container.querySelector('input') as HTMLInputElement;
+
+			// ensure the validation is made and errors are rendered
+			fireEvent.focus(input);
+			fireEvent.change(input, {
+				target: { value: 'no email' },
+			});
+			fireEvent.blur(input);
+
+			// find error fields
+			const errors = await findAllByTestId('error_field'); // validation is async, so we have to await
+			expect(errors).toHaveLength(2);
+			expect(getNodeText(errors[0])).toContain('field_too_short: hello');
+			expect(getNodeText(errors[1])).toContain('field_not_email: hello');
+
+			expect(container).toMatchSnapshot();
+		});
+	});
+});

--- a/test/__snapshots__/Validate.test.tsx.snap
+++ b/test/__snapshots__/Validate.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validate multiple validation errors can render multiple errors 1`] = `
+<div>
+  <form
+    novalidate=""
+  >
+    <div
+      class="MuiFormControl-root-2 MuiTextField-root-1 MuiFormControl-fullWidth-5"
+    >
+      <label
+        class="MuiFormLabel-root-18 MuiInputLabel-root-6 MuiInputLabel-formControl-12 MuiInputLabel-animated-15 MuiInputLabel-shrink-14 MuiFormLabel-error-22 MuiInputLabel-error-9 MuiFormLabel-filled-23 MuiFormLabel-required-24 MuiInputLabel-required-10"
+        data-shrink="true"
+      >
+        Test
+        <span
+          class="MuiFormLabel-asterisk-25 MuiInputLabel-asterisk-11 MuiFormLabel-error-22 MuiInputLabel-error-9"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root-40 MuiInput-root-26 MuiInput-underline-31 MuiInputBase-error-46 MuiInput-error-32 MuiInputBase-fullWidth-50 MuiInput-fullWidth-35 MuiInputBase-formControl-41 MuiInput-formControl-27"
+      >
+        <input
+          aria-invalid="true"
+          class="MuiInputBase-input-51 MuiInput-input-36"
+          data-testid="textfield"
+          name="hello"
+          required=""
+          type="text"
+          value="no email"
+        />
+      </div>
+      <p
+        class="MuiFormHelperText-root-58 MuiFormHelperText-error-59 MuiFormHelperText-filled-64 MuiFormHelperText-required-65"
+      >
+        field_too_short: hello
+        field_not_email: hello
+      </p>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Validate multiple validation errors can render multiple errors in seperate elements 1`] = `
+<div>
+  <form
+    novalidate=""
+  >
+    <div
+      class="MuiFormControl-root-2 MuiTextField-root-1 MuiFormControl-fullWidth-5"
+    >
+      <label
+        class="MuiFormLabel-root-18 MuiInputLabel-root-6 MuiInputLabel-formControl-12 MuiInputLabel-animated-15 MuiInputLabel-shrink-14 MuiFormLabel-error-22 MuiInputLabel-error-9 MuiFormLabel-filled-23 MuiFormLabel-required-24 MuiInputLabel-required-10"
+        data-shrink="true"
+      >
+        Test
+        <span
+          class="MuiFormLabel-asterisk-25 MuiInputLabel-asterisk-11 MuiFormLabel-error-22 MuiInputLabel-error-9"
+        >
+           
+          *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root-40 MuiInput-root-26 MuiInput-underline-31 MuiInputBase-error-46 MuiInput-error-32 MuiInputBase-fullWidth-50 MuiInput-fullWidth-35 MuiInputBase-formControl-41 MuiInput-formControl-27"
+      >
+        <input
+          aria-invalid="true"
+          class="MuiInputBase-input-51 MuiInput-input-36"
+          data-testid="textfield"
+          name="hello"
+          required=""
+          type="text"
+          value="no email"
+        />
+      </div>
+      <p
+        class="MuiFormHelperText-root-58 MuiFormHelperText-error-59 MuiFormHelperText-filled-64 MuiFormHelperText-required-65"
+      >
+        <span
+          data-testid="error_field"
+        >
+          field_too_short
+          : 
+          hello
+        </span>
+        <span
+          data-testid="error_field"
+        >
+          field_not_email
+          : 
+          hello
+        </span>
+      </p>
+    </div>
+  </form>
+</div>
+`;


### PR DESCRIPTION
This closes the issue opened by myself; https://github.com/lookfirst/mui-rff/issues/190

summary;
add possibility to pass a `translator` function to `makeValidate`. This gives overall better control of how error messages are handled. This function can also be used to just wrap errors in custom elements before they are passed off to material-ui