### PR TITLE
Issue 186 showError override prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ const initialValues: any = {
         label="Pick at least one planet"
         name="planet"
         multiple
-      />      
+      />
     </form>
   )}
 />
@@ -506,6 +506,40 @@ const required = makeRequired(schema);
 <Form validate={validate}>
   <Checkboxes name="employed" required={required.employed} data={{ label: 'Employed', value: true }} />
 </Form>
+```
+
+# Validation Types
+
+Every field we export will take a `showError` prop which is a function, which returns a boolean, that is used to determine how and when to show error messages, by using `meta` props from the FinalForm field state.
+
+These are the two available pre-defined options exported from within this library (defined in src/Util.tsx):
+
+## showErrorOnChange({ meta }) - default
+Triggers error messages to show up as soon as a value of a field changes. Useful for when the user needs instant feedback from the form validation (i.e. password creation rules, non-text based inputs like select, or switches etc.)
+
+## showErrorOnBlur({ meta })
+Triggers error messages to render after a field is touched, and blurred (focused out of), this is useful for text fields which might start out erronous but end up valid in the end (i.e. email, or zipcode). In these cases you don't want to rush to show the user a validation error message when they haven't had a chance to finish their entry.
+
+```tsx
+import { TextField, showErrorOnBlur } from 'mui-rff';
+
+<TextField label="Hello world" name="hello" required={true} showError={showErrorOnBlur}/>
+```
+
+## You can also make your own override:
+
+```tsx
+import { TextField } from 'mui-rff';
+
+// define your own showError-type function
+function myShowErrorFunction({
+	meta: { submitError, dirtySinceLastSubmit, error, touched, modified },
+}){
+  // this is actually the contents of showErrorOnBlur but you can be as creative as you want.
+  return !!(((submitError && !dirtySinceLastSubmit) || error) && touched);
+}
+
+<TextField label="Hello world" name="hello" required={true} showError={myShowErrorFunction}/>
 ```
 
 ## Debug

--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -8,7 +8,7 @@ import {
 	AutocompleteProps as MuiAutocompleteProps,
 	RenderInputParams as MuiAutocompleteRenderInputParams,
 } from '@material-ui/lab/Autocomplete';
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 
 export type AutocompleteData = {
 	[key: string]: any | null;
@@ -56,6 +56,7 @@ const AutocompleteWrapper = (props: AutocompleteWrapperProps) => {
 		multiple,
 		textFieldProps,
 		getOptionValue,
+		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -32,7 +32,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
 	return (
 		<Field
 			name={name}
-			render={(fieldRenderProps) => <AutocompleteWrapper {...fieldRenderProps} {...rest} />}
+			render={fieldRenderProps => <AutocompleteWrapper {...fieldRenderProps} {...rest} />}
 			{...fieldProps}
 		/>
 	);

--- a/src/Checkboxes.tsx
+++ b/src/Checkboxes.tsx
@@ -14,7 +14,7 @@ import {
 import React, { ReactNode } from 'react';
 
 import { Field, FieldProps } from 'react-final-form';
-import { ErrorMessage, showError, useFieldForErrors } from './Util';
+import { ErrorMessage, showErrorOnChange, useFieldForErrors } from './Util';
 
 export interface CheckboxData {
 	label: ReactNode;
@@ -34,6 +34,7 @@ export interface CheckboxesProps extends Partial<Omit<MuiCheckboxProps, 'onChang
 	formLabelProps?: Partial<FormLabelProps>;
 	formControlLabelProps?: Partial<FormControlLabelProps>;
 	formHelperTextProps?: Partial<FormHelperTextProps>;
+	showError?: Function;
 }
 
 export function Checkboxes(props: CheckboxesProps) {
@@ -49,6 +50,7 @@ export function Checkboxes(props: CheckboxesProps) {
 		formLabelProps,
 		formControlLabelProps,
 		formHelperTextProps,
+		showError = showErrorOnChange,
 		...restCheckboxes
 	} = props;
 

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -18,7 +18,7 @@ export function DatePicker(props: DatePickerProps) {
 	return (
 		<Field
 			name={name as any}
-			render={(fieldRenderProps) => <DatePickerWrapper {...fieldRenderProps} {...rest} />}
+			render={fieldRenderProps => <DatePickerWrapper {...fieldRenderProps} {...rest} />}
 			{...fieldProps}
 		/>
 	);
@@ -34,7 +34,6 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 		meta,
 		dateFunsUtils,
 		showError = showErrorOnChange,
-
 		...rest
 	} = props;
 

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -4,7 +4,7 @@ import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } fr
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 import pickerProviderWrapper from './PickerProvider';
 
 export interface DatePickerProps extends Partial<Omit<MuiDatePickerProps, 'onChange'>> {
@@ -33,6 +33,8 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 		input: { name, onChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		showError = showErrorOnChange,
+
 		...rest
 	} = props;
 

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
-import { DateTimePicker as MuiDateTimePicker, DateTimePickerProps as MuiDateTimePickerProps } from '@material-ui/pickers';
+import {
+	DateTimePicker as MuiDateTimePicker,
+	DateTimePickerProps as MuiDateTimePickerProps,
+} from '@material-ui/pickers';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 import pickerProviderWrapper from './PickerProvider';
 
 export interface DateTimePickerProps extends Partial<Omit<MuiDateTimePickerProps, 'onChange'>> {
@@ -18,7 +21,7 @@ export function DateTimePicker(props: DateTimePickerProps) {
 	return (
 		<Field
 			name={name as any}
-			render={(fieldRenderProps) => <DateTimePickerWrapper {...fieldRenderProps} {...rest} />}
+			render={fieldRenderProps => <DateTimePickerWrapper {...fieldRenderProps} {...rest} />}
 			{...fieldProps}
 		/>
 	);
@@ -33,6 +36,7 @@ function DateTimePickerWrapper(props: DateTimePickerWrapperProps) {
 		input: { name, onChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/KeyboardDatePicker.tsx
+++ b/src/KeyboardDatePicker.tsx
@@ -35,7 +35,7 @@ function KeyboardDatePickerWrapper(props: DatePickerWrapperProps) {
 	const {
 		input: { name, onChange, value, ...restInput },
 		meta,
-		dateFunsUtils,
+		dateFunsUtils,		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/KeyboardDatePicker.tsx
+++ b/src/KeyboardDatePicker.tsx
@@ -7,7 +7,7 @@ import {
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 import pickerProviderWrapper from './PickerProvider';
 
 export interface KeyboardDatePickerProps extends Partial<Omit<MuiKeyboardDatePickerProps, 'onChange'>> {

--- a/src/KeyboardDateTimePicker.tsx
+++ b/src/KeyboardDateTimePicker.tsx
@@ -7,7 +7,7 @@ import {
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 import pickerProviderWrapper from './PickerProvider';
 
 export interface KeyboardDateTimePickerProps extends Partial<Omit<MuiKeyboardDateTimePickerProps, 'onChange'>> {
@@ -21,7 +21,7 @@ export function KeyboardDateTimePicker(props: KeyboardDateTimePickerProps) {
 	return (
 		<Field
 			name={name as any}
-			render={(fieldRenderProps) => <KeyboardDateTimePickerWrapper {...fieldRenderProps} {...rest} />}
+			render={fieldRenderProps => <KeyboardDateTimePickerWrapper {...fieldRenderProps} {...rest} />}
 			{...fieldProps}
 		/>
 	);
@@ -36,6 +36,7 @@ function KeyboardDateTimePickerWrapper(props: DatePickerWrapperProps) {
 		input: { name, onChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/KeyboardTimePicker.tsx
+++ b/src/KeyboardTimePicker.tsx
@@ -7,7 +7,7 @@ import {
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 import pickerProviderWrapper from './PickerProvider';
 
 export interface KeyboardTimePickerProps extends Partial<Omit<MuiKeyboardTimePickerProps, 'onChange'>> {

--- a/src/KeyboardTimePicker.tsx
+++ b/src/KeyboardTimePicker.tsx
@@ -21,7 +21,7 @@ export function KeyboardTimePicker(props: KeyboardTimePickerProps) {
 	return (
 		<Field
 			name={name as any}
-			render={(fieldRenderProps) => <KeyboardTimePickerWrapper {...fieldRenderProps} {...rest} />}
+			render={fieldRenderProps => <KeyboardTimePickerWrapper {...fieldRenderProps} {...rest} />}
 			{...fieldProps}
 		/>
 	);
@@ -36,6 +36,7 @@ function KeyboardTimePickerWrapper(props: KeyboardTimePickerWrapperProps) {
 		input: { name, onChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/Radios.tsx
+++ b/src/Radios.tsx
@@ -15,7 +15,7 @@ import {
 } from '@material-ui/core';
 
 import { Field, FieldProps } from 'react-final-form';
-import { ErrorMessage, showError, useFieldForErrors } from './Util';
+import { ErrorMessage, showErrorOnChange, useFieldForErrors } from './Util';
 
 export interface RadioData {
 	label: ReactNode;
@@ -35,6 +35,7 @@ export interface RadiosProps extends Partial<Omit<MuiRadioProps, 'onChange'>> {
 	formControlProps?: Partial<FormControlProps>;
 	radioGroupProps?: Partial<RadioGroupProps>;
 	formHelperTextProps?: Partial<FormHelperTextProps>;
+	showError?: Function;
 }
 
 export function Radios(props: RadiosProps) {
@@ -50,6 +51,7 @@ export function Radios(props: RadiosProps) {
 		formControlProps,
 		radioGroupProps,
 		formHelperTextProps,
+		showError = showErrorOnChange,
 		...restRadios
 	} = props;
 

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -13,7 +13,7 @@ import {
 } from '@material-ui/core';
 
 import { Field, FieldProps } from 'react-final-form';
-import { ErrorMessage, showError, useFieldForErrors } from './Util';
+import { ErrorMessage, showErrorOnChange, useFieldForErrors } from './Util';
 
 export interface SelectData {
 	label: string;
@@ -31,6 +31,7 @@ export interface SelectProps extends Partial<Omit<MuiSelectProps, 'onChange'>> {
 	formControlProps?: Partial<FormControlProps>;
 	inputLabelProps?: Partial<InputLabelProps>;
 	formHelperTextProps?: Partial<FormHelperTextProps>;
+	showError?: Function;
 	menuItemProps?: Partial<MenuItemProps>;
 	data?: SelectData[];
 	children?: React.ReactElement | React.ReactElement[];
@@ -51,6 +52,7 @@ export function Select(props: SelectProps) {
 		formHelperTextProps,
 		menuItemProps,
 		labelWidth,
+		showError = showErrorOnChange,
 		...restSelectProps
 	} = props;
 
@@ -97,7 +99,7 @@ export function Select(props: SelectProps) {
 							{...restSelectProps}
 						>
 							{data
-								? data.map((item) => (
+								? data.map(item => (
 										<MenuItem
 											value={item.value}
 											key={item.value}

--- a/src/Switches.tsx
+++ b/src/Switches.tsx
@@ -15,7 +15,7 @@ import {
 } from '@material-ui/core';
 
 import { Field, FieldProps } from 'react-final-form';
-import { ErrorMessage, showError, useFieldForErrors } from './Util';
+import { ErrorMessage, showErrorOnChange, useFieldForErrors } from './Util';
 
 export interface SwitchData {
 	label: ReactNode;
@@ -35,6 +35,7 @@ export interface SwitchesProps extends Partial<Omit<MuiSwitchProps, 'onChange'>>
 	formLabelProps?: Partial<FormLabelProps>;
 	formControlLabelProps?: Partial<FormControlLabelProps>;
 	formHelperTextProps?: Partial<FormHelperTextProps>;
+	showError?: Function;
 }
 
 export function Switches(props: SwitchesProps) {
@@ -50,6 +51,7 @@ export function Switches(props: SwitchesProps) {
 		formLabelProps,
 		formControlLabelProps,
 		formHelperTextProps,
+		showError = showErrorOnChange,
 		...restSwitches
 	} = props;
 

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { TextField as MuiTextField, TextFieldProps as MuiTextFieldProps } from '@material-ui/core';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 
 export const TYPE_PASSWORD = 'password';
 export const TYPE_TEXT = 'text';
@@ -61,6 +61,7 @@ export function TextFieldWrapper(props: TextWrapperProps) {
 		required,
 		fullWidth = true,
 		helperText,
+		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/TimePicker.tsx
+++ b/src/TimePicker.tsx
@@ -18,7 +18,7 @@ export function TimePicker(props: TimePickerProps) {
 	return (
 		<Field
 			name={name as any}
-			render={(fieldRenderProps) => <TimePickerWrapper {...fieldRenderProps} {...rest} />}
+			render={fieldRenderProps => <TimePickerWrapper {...fieldRenderProps} {...rest} />}
 			{...fieldProps}
 		/>
 	);
@@ -33,6 +33,7 @@ function TimePickerWrapper(props: TimePickerWrapperProps) {
 		input: { name, onChange, value, ...restInput },
 		meta,
 		dateFunsUtils,
+		showError = showErrorOnChange,
 		...rest
 	} = props;
 

--- a/src/TimePicker.tsx
+++ b/src/TimePicker.tsx
@@ -4,7 +4,7 @@ import { TimePicker as MuiTimePicker, TimePickerProps as MuiTimePickerProps } fr
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
-import { showError } from './Util';
+import { showErrorOnChange } from './Util';
 import pickerProviderWrapper from './PickerProvider';
 
 export interface TimePickerProps extends Partial<Omit<MuiTimePickerProps, 'onChange'>> {

--- a/src/Util.tsx
+++ b/src/Util.tsx
@@ -20,7 +20,7 @@ export function ErrorMessage({ showError, meta, formHelperTextProps, helperText 
 	}
 }
 
-export interface showErrorProps {
+export interface ShowErrorProps {
 	meta: FieldMetaState<any>;
 }
 
@@ -40,10 +40,10 @@ export function useFieldForErrors(name: string) {
 
 export function showErrorOnChange({
 	meta: { submitError, dirtySinceLastSubmit, error, touched, modified },
-}: showErrorProps) {
+}: ShowErrorProps) {
 	return !!(((submitError && !dirtySinceLastSubmit) || error) && (touched || modified));
 }
 
-export function showErrorOnBlur({ meta: { submitError, dirtySinceLastSubmit, error, touched } }: showErrorProps) {
+export function showErrorOnBlur({ meta: { submitError, dirtySinceLastSubmit, error, touched } }: ShowErrorProps) {
 	return !!(((submitError && !dirtySinceLastSubmit) || error) && touched);
 }

--- a/src/Util.tsx
+++ b/src/Util.tsx
@@ -38,6 +38,12 @@ export function useFieldForErrors(name: string) {
 	return useField(name, config);
 }
 
-export function showError({ meta: { submitError, dirtySinceLastSubmit, error, touched, modified } }: showErrorProps) {
+export function showErrorOnChange({
+	meta: { submitError, dirtySinceLastSubmit, error, touched, modified },
+}: showErrorProps) {
 	return !!(((submitError && !dirtySinceLastSubmit) || error) && (touched || modified));
+}
+
+export function showErrorOnBlur({ meta: { submitError, dirtySinceLastSubmit, error, touched } }: showErrorProps) {
+	return !!(((submitError && !dirtySinceLastSubmit) || error) && touched);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,4 +12,11 @@ export { TimePicker, TimePickerProps } from './TimePicker';
 export { TextField, TextFieldProps } from './TextField';
 export { makeValidate, makeValidateSync, makeRequired } from './Validation';
 export { Debug } from './Debug';
-export { ErrorMessageProps, ErrorMessage, showErrorProps, showError, useFieldForErrors } from './Util';
+export {
+	ErrorMessageProps,
+	ErrorMessage,
+	ShowErrorProps,
+	showErrorOnBlur,
+	showErrorOnChange,
+	useFieldForErrors,
+} from './Util';


### PR DESCRIPTION
take 2 for this: https://github.com/lookfirst/mui-rff/issues/186

I believe this should cover what we discussed in the issue above, and in my [previous PR](https://github.com/lookfirst/mui-rff/pull/191).

TL;DR this will allow users to override the default `showError` function by either passing their own or one of the two pre-defined options that i exported out of Util. Also updated the readme with a new section regarding how to use this. Let me know if there's anything else needed to merge this.