### PR TITLE
when Autocomplete in freeSolo, ensure that changes are propagated asap

### DIFF
--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -102,7 +102,7 @@ function AutocompleteWrapper<
 		return multiple ? (values ? values.map(getOptionValue) : null) : values ? getOptionValue(values) : null;
 	}
 
-	const { helperText, ...lessrest } = rest;
+	const { helperText, freeSolo, ...lessrest } = rest;
 	const { variant, ...restTextFieldProps } = textFieldProps || {};
 
 	// yuck...
@@ -188,6 +188,12 @@ function AutocompleteWrapper<
 					fullWidth={true}
 				/>
 			)}
+			{
+				...freeSolo && {
+					freeSolo,
+					onInputChange: onChangeFunc
+				}
+			}
 			{...lessrest}
 		/>
 	);


### PR DESCRIPTION
fixes #375 
- fixes Autocomplete not "broadcasting" intermediate changes in freeSolo mode. Since freeSolo allows the user to enter whatever they want (and not only from the options) Autocomplete should essentially behave identical to a TextField