### PR TITLE
Draft fix for #520

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepublish": "yarn build",
     "postpublish": "yarn deploy",
     "prepare": "husky install",
-    "postinstall": "patch-package"
+    "patch": "patch-package"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepublish": "yarn build",
     "postpublish": "yarn deploy",
     "prepare": "husky install",
-    "patch": "patch-package"
+    "postinstall": "yarn run patch-package"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
So basically one can't use `postinstall` script for patching modules like that. Because `postinstall` in not a developer-only thing, but it affects package users as well. Temporarily renamed it to a free name `patch`. 