### PR TITLE
props.error overrides by renderInput props

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -55,13 +55,13 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 			{...lessrest}
 			renderInput={(props) => (
 				<TextField
+					{...props}
 					fullWidth={true}
 					helperText={isError ? error || submitError : helperText}
 					error={isError}
 					name={name}
 					required={required}
 					{...restInput}
-					{...props}
 				/>
 			)}
 		/>,


### PR DESCRIPTION
If I pass validate to DatePicker field, then I have 

if I pass a validate function to a DatePicker, then it is triggered, then the error is displayed incorrectly because the error prop is overwritten by renderInput props