### PR TITLE
Fix autocomplete onChange functionality when freeSolo is active

### DIFF
--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -73,7 +73,7 @@ function AutocompleteWrapper<
 	props: AutocompleteWrapperProps<T, Multiple, DisableClearable, FreeSolo> & FieldRenderProps<MuiTextFieldProps>,
 ): JSX.Element {
 	const {
-		input: { name, value, onChange },
+		input: { name, value, onChange, onBlur, onFocus },
 		meta,
 		options,
 		label,
@@ -179,6 +179,9 @@ function AutocompleteWrapper<
 							),
 						}),
 					}}
+					onFocus={onFocus}
+					onBlur={onBlur}
+					onChange={onChange}
 					fullWidth={true}
 				/>
 			)}

--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -75,6 +75,7 @@ function AutocompleteWrapper<
 	const {
 		input: { name, value, onChange, onBlur, onFocus },
 		meta,
+		freeSolo,
 		options,
 		label,
 		required,
@@ -141,7 +142,11 @@ function AutocompleteWrapper<
 
 	const { error, submitError } = meta;
 	const isError = showError({ meta });
-
+	const textFieldFreeSolo = freeSolo && {
+		onBlur,
+		onFocus,
+		onChange,
+	};
 	return (
 		<MuiAutocomplete
 			multiple={multiple}
@@ -179,9 +184,7 @@ function AutocompleteWrapper<
 							),
 						}),
 					}}
-					onFocus={onFocus}
-					onBlur={onBlur}
-					onChange={onChange}
+					{...textFieldFreeSolo}
 					fullWidth={true}
 				/>
 			)}


### PR DESCRIPTION
We had issue with onChange functionality on the autocomplete component when freeSolo mode is active.
The issue was that the form was not detecting and keeping the typed changes, also the validation was not working correctly. The validation was working only onClick - the select functionality.