### PR TITLE
Yup now provides its own type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It is unfortunate that so many dependencies need to be installed right now. Pret
 
 I recommend using Yup for the form validation:
 
-`yarn add yup @types/yup`
+`yarn add yup`
 
 # Getting started
 


### PR DESCRIPTION
Yup ships its own type definitions when Yup is installed. It's no longer necessary to add @types/yup.
Reference: https://www.npmjs.com/package/@types/yup