### PR TITLE
fix: DatePicker with textFieldProps

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 
 import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from '@mui/x-date-pickers';
-import TextField from '@mui/material/TextField';
+import TextField, { TextFieldProps } from '@mui/material/TextField';
 
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
 import { ShowErrorFunc, showErrorOnChange } from './Util';
 
 export interface DatePickerProps extends Partial<Omit<MuiDatePickerProps<any, any>, 'onChange'>> {
-	name: string;
-	locale?: any;
 	fieldProps?: Partial<FieldProps<any, any>>;
+	locale?: any;
+	name: string;
 	required?: boolean;
 	showError?: ShowErrorFunc;
+	textFieldProps?: TextFieldProps;
 }
 
 export function DatePicker(props: DatePickerProps) {
@@ -43,7 +44,7 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 	const { error, submitError } = meta;
 	const isError = showError({ meta });
 
-	const { helperText, ...lessrest } = rest;
+	const { helperText, textFieldProps, ...lessrest } = rest;
 
 	return (
 		<MuiDatePicker
@@ -52,6 +53,7 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 			{...lessrest}
 			renderInput={(inputProps) => (
 				<TextField
+					{...textFieldProps}
 					{...inputProps}
 					fullWidth={true}
 					helperText={isError ? error || submitError : helperText}

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -8,14 +8,15 @@ import {
 import { Field, FieldProps, FieldRenderProps } from 'react-final-form';
 
 import { ShowErrorFunc, showErrorOnChange } from './Util';
-import { TextField } from '@mui/material';
+import TextField, { TextFieldProps } from '@mui/material/TextField';
 
 export interface DateTimePickerProps extends Partial<Omit<MuiDateTimePickerProps<any, any>, 'onChange'>> {
-	name: string;
-	locale?: any;
 	fieldProps?: Partial<FieldProps<any, any>>;
+	locale?: any;
+	name: string;
 	required?: boolean;
 	showError?: ShowErrorFunc;
+	textFieldProps?: TextFieldProps;
 }
 
 export function DateTimePicker(props: DateTimePickerProps) {
@@ -47,7 +48,7 @@ function DateTimePickerWrapper(props: DateTimePickerWrapperProps) {
 	const { error, submitError } = meta;
 	const isError = showError({ meta });
 
-	const { helperText, ...lessrest } = rest;
+	const { helperText, textFieldProps, ...lessrest } = rest;
 
 	return (
 		<MuiDateTimePicker
@@ -56,6 +57,7 @@ function DateTimePickerWrapper(props: DateTimePickerWrapperProps) {
 			{...lessrest}
 			renderInput={(inputProps) => (
 				<TextField
+					{...textFieldProps}
 					{...inputProps}
 					fullWidth={true}
 					helperText={isError ? error || submitError : helperText}

--- a/test/DatePicker.test.tsx
+++ b/test/DatePicker.test.tsx
@@ -7,11 +7,11 @@ import { Form } from 'react-final-form';
 import 'date-fns';
 
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { DatePicker, makeValidateSync } from '../src';
+import { DatePicker, DatePickerProps, makeValidateSync } from '../src';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { fireEvent, render } from '@testing-library/react';
 
-interface ComponentProps {
+interface ComponentProps extends Omit<DatePickerProps, 'name'> {
 	initialValues: FormData;
 	validator?: any;
 }
@@ -28,7 +28,7 @@ describe('DatePicker', () => {
 		date: new Date(defaultDateString),
 	};
 
-	function DatePickerComponent({ initialValues, validator }: ComponentProps) {
+	function DatePickerComponent({ initialValues, validator, ...rest }: ComponentProps) {
 		const onSubmit = (values: FormData) => {
 			console.log(values);
 		};
@@ -41,7 +41,7 @@ describe('DatePicker', () => {
 				render={({ handleSubmit, submitting }) => (
 					<form onSubmit={handleSubmit} noValidate>
 						<LocalizationProvider dateAdapter={AdapterDateFns}>
-							<DatePicker label="Test" name="date" required={true} inputFormat="yyyy-MM-dd" />
+							<DatePicker label="Test" name="date" required={true} inputFormat="yyyy-MM-dd" {...rest} />
 						</LocalizationProvider>
 
 						<Button
@@ -97,5 +97,13 @@ describe('DatePicker', () => {
 
 		//const elem = (await findByText('Test')) as HTMLLegendElement;
 		expect(rendered).toMatchSnapshot();
+	});
+
+	it('renders as standard variant as well', async () => {
+		const rendered = render(
+			<DatePickerComponent initialValues={initialValues} textFieldProps={{ variant: 'standard' }} />,
+		);
+
+		expect(rendered.getByText('Test').classList.contains('MuiInputLabel-standard')).toBe(true);
 	});
 });

--- a/test/DateTimePicker.test.tsx
+++ b/test/DateTimePicker.test.tsx
@@ -7,12 +7,12 @@ import 'date-fns';
 import * as Yup from 'yup';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { Button } from '@mui/material';
-import { DateTimePicker } from '../src';
+import { DateTimePicker, DateTimePickerProps } from '../src';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { act, fireEvent, render } from '@testing-library/react';
 import { makeValidateSync } from '../src';
 
-interface ComponentProps {
+interface ComponentProps extends Omit<DateTimePickerProps, 'name'> {
 	initialValues: FormData;
 	validator?: any;
 }
@@ -30,7 +30,7 @@ describe('DateTimePicker', () => {
 		date: new Date(defaultDateString),
 	};
 
-	function DateTimePickerComponent({ initialValues, validator }: ComponentProps) {
+	function DateTimePickerComponent({ initialValues, validator, ...rest }: ComponentProps) {
 		const onSubmit = (values: FormData) => {
 			console.log(values);
 		};
@@ -43,7 +43,7 @@ describe('DateTimePicker', () => {
 				render={({ handleSubmit, submitting }) => (
 					<form onSubmit={handleSubmit} noValidate>
 						<LocalizationProvider dateAdapter={AdapterDateFns}>
-							<DateTimePicker label="Test" name="date" required={true} />
+							<DateTimePicker label="Test" name="date" required={true} {...rest} />
 						</LocalizationProvider>
 
 						<Button
@@ -104,5 +104,13 @@ describe('DateTimePicker', () => {
 		fireEvent.click(submit);
 
 		expect(rendered).toMatchSnapshot();
+	});
+
+	it('renders as standard variant as well', async () => {
+		const rendered = render(
+			<DateTimePickerComponent initialValues={initialValues} textFieldProps={{ variant: 'standard' }} />,
+		);
+
+		expect(rendered.getByText('Test').classList.contains('MuiInputLabel-standard')).toBe(true);
 	});
 });


### PR DESCRIPTION
I've created this PR to add the possibility to pass `TextFieldProps` to the `TextField` component.

It's been created originally to fix #920 