### PR TITLE
Pass slotProps to DatePickers

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -45,7 +45,7 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 	const { error, submitError } = meta;
 	const isError = showError({ meta });
 
-	const { helperText, textFieldProps, required, ...lessRest } = rest;
+	const { helperText, textFieldProps, slotProps, required, ...lessRest } = rest;
 
 	return (
 		<MuiDatePicker
@@ -53,6 +53,7 @@ function DatePickerWrapper(props: DatePickerWrapperProps) {
 			value={(value as any) === '' ? null : value}
 			{...lessRest}
 			slotProps={{
+				...slotProps,
 				textField: {
 					...textFieldProps,
 					helperText: isError ? error || submitError : helperText,

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -45,7 +45,7 @@ function DateTimePickerWrapper(props: DateTimePickerWrapperProps) {
 	const { error, submitError } = meta;
 	const isError = showError({ meta });
 
-	const { helperText, textFieldProps, required, ...lessRest } = rest;
+	const { helperText, textFieldProps, slotProps, required, ...lessRest } = rest;
 
 	return (
 		<MuiDateTimePicker
@@ -53,6 +53,7 @@ function DateTimePickerWrapper(props: DateTimePickerWrapperProps) {
 			value={(value as any) === '' ? null : value}
 			{...lessRest}
 			slotProps={{
+				...slotProps,
 				textField: {
 					...textFieldProps,
 					helperText: isError ? error || submitError : helperText,


### PR DESCRIPTION
Allows other `slotProps` to be spread into the MuiDatePicker and MuiDateTimePicker. One use case is for passing in the the action bar: https://v7.mui.com/x/react-date-pickers/custom-components/#action-bar