### PR TITLE
chore(vite): split vendor chunks to avoid large chunk size warnings a…

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -9,7 +9,15 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'mui-material': ['@mui/material', '@mui/system'],
+          'x-date-pickers': ['@mui/x-date-pickers'],
+        },
+      },
+    },
   },
   resolve: {
     dedupe: [


### PR DESCRIPTION
**Changes**

- Disabled sourcemap generation in the production build to reduce output size.
- Added manual chunk splitting for key dependencies:
    - @mui/material and @mui/system are grouped into a mui-material chunk.
    - @mui/x-date-pickers is separated into its own x-date-pickers chunk.