### PR TITLE
fix: use relative asset paths for GitHub Pages deployment

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   server: {
     port: 3000,


### PR DESCRIPTION
## Fix: Use Relative Asset Paths for GitHub Pages Deployment

### What does this PR do?
This pull request updates the Vite configuration in the example app to set the `base` option to `'./'`. This change ensures that all asset paths are relative, which is required for correct asset loading when the app is deployed to GitHub Pages.

### Why is this needed?
GitHub Pages serves static files from a subdirectory (e.g., `/mui-rff/`), so absolute asset paths (e.g., `/assets/...`) result in 404 errors. By using relative paths (`./assets/...`), the app can correctly load assets regardless of the deployment path.

#1200
