### PR TITLE
Fix/mui checkbox onblur touched

### DIFF
--- a/src/Checkboxes.tsx
+++ b/src/Checkboxes.tsx
@@ -75,14 +75,18 @@ export function Checkboxes(props: CheckboxesProps) {
 							<Field
 								type="checkbox"
 								name={name}
-								render={({ input: { name, value, onChange, checked, ...restInput } }) => (
+								render={({
+									input: { name, value, onChange, checked, onBlur, onFocus, ...restInput },
+								}) => (
 									<MuiCheckbox
 										name={name}
 										value={value}
 										onChange={onChange}
 										checked={checked}
 										disabled={item.disabled}
-										inputProps={{ required, ...restInput }}
+										slotProps={{
+											input: { required, onBlur, onFocus, ...restInput },
+										}}
 										indeterminate={item.indeterminate}
 										{...restCheckboxes}
 									/>

--- a/src/Radios.tsx
+++ b/src/Radios.tsx
@@ -73,7 +73,9 @@ export function Radios(props: RadiosProps) {
 							<Field
 								name={name}
 								type="radio"
-								render={({ input: { name, value, onChange, checked, ...restInput } }) => (
+								render={({
+									input: { name, value, onChange, checked, onBlur, onFocus, ...restInput },
+								}) => (
 									<MuiRadio
 										name={name}
 										value={value}
@@ -81,7 +83,14 @@ export function Radios(props: RadiosProps) {
 										checked={checked}
 										disabled={item.disabled}
 										required={required}
-										inputProps={{ required, ...restInput }}
+										slotProps={{
+											input: {
+												required,
+												onBlur,
+												onFocus,
+												...restInput,
+											},
+										}}
 										{...restRadios}
 									/>
 								)}


### PR DESCRIPTION
**Fix:** Ensure `onBlur` is passed to MUI Checkbox so the field is correctly marked as touched

This resolves an issue where checkboxes and radios were not updating the touched state after blur, as described in [#1187](https://github.com/lookfirst/mui-rff/issues/1187).

The fix ensures the Final Form `onBlur` handler is not overwritten and is always passed to the input.