### PR TITLE
Fix: remove hardcoded yarn engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
 		"src"
 	],
 	"engines": {
-		"node": ">=18.0.0",
-		"yarn": ">=4.0.0"
+		"node": ">=18.0.0"
 	},
 	"workspaces": [
 		"example"


### PR DESCRIPTION
As mentioned in https://github.com/lookfirst/mui-rff/discussions/1255, the package shouldn't care if an older version of yarn is used. The hardcoded version in package.json causes installations with older yarn versions to break